### PR TITLE
BOM Fix

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -249,7 +249,7 @@ var EX_EOF = {};
 function tokenizer($TEXT, skip_comments) {
 
         var S = {
-                text           : $TEXT.replace(/\r\n?|[\n\u2028\u2029]/g, "\n"),
+                text           : $TEXT.replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/^\uFEFF/, ''),
                 pos            : 0,
                 tokpos         : 0,
                 line           : 0,


### PR DESCRIPTION
Fix so that the parser doesn't die on files that contain a Byte Order Mark at the beginning.
