### PR TITLE
bad node version check

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -1,7 +1,7 @@
 #! /usr/bin/env node
 // -*- js2 -*-
 
-global.sys = require(/^0\.2/.test(process.version) ? "sys" : "util");
+global.sys = require(/^v0\.[012]/.test(process.version) ? "sys" : "util");
 var fs = require("fs");
 var jsp = require("uglifyjs/parse-js"); // symlink ~/.node_libraries/uglifyjs => /path/to/../lib/
 var pro = require("uglifyjs/process");


### PR DESCRIPTION
it was missing the leading `v` and was unsafe for versions <0.2
