### PR TITLE
Make npm link work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
-{"name"    : "UglifyJS",
+{"name"    : "uglify-js",
  "author"  : "Mihai Bazon - http://github.com/mishoo",
  "version" : "0.0.1",
- "directories" : {"lib": "./lib"},
+ "main"    : "index.js",
  "bin"     : { "uglifyjs" : "./bin/uglifyjs" },
 }


### PR DESCRIPTION
With the changes to the name of uglify-js for requiring in node it was no longer possible to use npm to link the source for use system wide. This small change makes the `uglifyjs` executable work again and promotes using the top level `require('uglify-js')` statement.
