### PR TITLE
Fixed printing small floating-point numbers

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1108,7 +1108,7 @@ function gen_code(ast, beautify) {
                                 a.push(m[1] + "e" + m[2].length);
                         }
                 } else if ((m = /^0?\.(0+)(.*)$/.exec(num))) {
-                        a.push(m[2] + "e-" + (m[1].length + 1),
+                        a.push(m[2] + "e-" + (m[1].length + m[2].length),
                                str.substr(str.indexOf(".")));
                 }
                 return best_of(a);


### PR DESCRIPTION
The code for printing small (<1) floating-point numbers was incorrect, which resulted in incorrect conversions like 0.00015 to 15e-4. The issue was that the length of the significant figures (i.e. the 15 in the previous example) was not taken into account for the exponent.
