### PR TITLE
Convenience function for minification

### DIFF
--- a/uglify-js.js
+++ b/uglify-js.js
@@ -1,2 +1,17 @@
-exports.parser = require("./lib/parse-js");
-exports.uglify = require("./lib/process");
+//convienence function(src, [options]);
+function uglify(orig_code, options){
+  options || (options = {});
+  var jsp = uglify.parser;
+  var pro = uglify.uglify;
+
+  var ast = jsp.parse(orig_code, options.strict_semicolons); // parse code and get the initial AST
+  ast = pro.ast_mangle(ast, options.mangle_options); // get a new AST with mangled names
+  ast = pro.ast_squeeze(ast, options.squeeze_options); // get an AST with compression optimizations
+  var final_code = pro.gen_code(ast, options.gen_options); // compressed code here
+  return final_code;
+};
+
+uglify.parser = require("./lib/parse-js");
+uglify.uglify = require("./lib/process");
+
+module.exports = uglify


### PR DESCRIPTION
make the module exports a convenience function so minifying src with the defaults is just a one-lininer: 

`min = require('uglify-js')(src);`

of course, require('uglify-js').uglify and require('uglify-js').parser are still exposed.

I am unfamiliar with the documentation generator you use, so I did not update the README.

Addresses Issue 132.
