### PR TITLE
Adds missing whitespace characters to WHITESPACE_CHARS

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -189,7 +189,7 @@ var OPERATORS = array_to_hash([
         "||"
 ]);
 
-var WHITESPACE_CHARS = array_to_hash(characters(" \n\r\t\u200b"));
+var WHITESPACE_CHARS = array_to_hash(characters(" \u00a0\n\r\t\f\v\u200b"));
 
 var PUNC_BEFORE_EXPRESSION = array_to_hash(characters("[{}(,.;:"));
 


### PR DESCRIPTION
UglifyJS was missing some of the whitespace characters defined by the ECMAScript5 specs, it seems: `form feed',`vertical tab' and `no-break space'. This patch adds them.

Also fixes issue #148
