### PR TITLE
Encode null characters as '\0'

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1075,7 +1075,7 @@ var DOT_CALL_NO_PARENS = jsp.array_to_hash([
 
 function make_string(str, ascii_only) {
         var dq = 0, sq = 0;
-        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029]/g, function(s){
+        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g, function(s){
                 switch (s) {
                     case "\\": return "\\\\";
                     case "\b": return "\\b";
@@ -1087,6 +1087,7 @@ function make_string(str, ascii_only) {
                     case "\u2029": return "\\u2029";
                     case '"': ++dq; return '"';
                     case "'": ++sq; return "'";
+                    case "\0": return "\\0";
                 }
                 return s;
         });

--- a/test/unit/compress/expected/null_string.js
+++ b/test/unit/compress/expected/null_string.js
@@ -1,0 +1,1 @@
+var nullString="\0"

--- a/test/unit/compress/test/null_string.js
+++ b/test/unit/compress/test/null_string.js
@@ -1,0 +1,1 @@
+var nullString = "\0"


### PR DESCRIPTION
Some (non-browser) implementations seem to have difficulties with handling null characters inside JS strings (lautis/uglifier#11). Also, I'm not sure if it's a good idea to convert visible characters to invisible ones when minifying code. Copy-paste could lead to corruption.

While having null characters is perfectly fine in JS string literals (AFAIK), I don't think they should be optimized because of potential issues.
