### PR TITLE
Return if2

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -977,6 +977,90 @@ function ast_squeeze(ast, options) {
                 });
         };
 
+        // In this first pass, we rewrite ifs which abort with no else with an
+        // if-else.  For example:
+        //
+        // if (x) {
+        //     blah();
+        //     return y;
+        // }
+        // foobar();
+        //
+        // is rewritten into:
+        //
+        // if (x) {
+        //     blah();
+        //     return y;
+        // } else {
+        //     foobar();
+        // }
+        function redo_if(statements) {
+                statements = MAP(statements, walk);
+
+                for (var i = 0; i < statements.length; ++i) {
+                        var fi = statements[i];
+                        if (fi[0] != "if") continue;
+
+                        if (fi[3] && walk(fi[3])) continue;
+
+                        var t = walk(fi[2]);
+                        if (!aborts(t)) continue;
+
+                        var conditional = walk(fi[1]);
+
+                        var e_body = statements.slice(i + 1);
+                        var e;
+                        if (e_body.length == 1) e = e_body[0];
+                        else e = [ "block", e_body ];
+
+                        var ret = statements.slice(0, i).concat([ [
+                                fi[0],          // "if"
+                                conditional,    // conditional
+                                t,              // then
+                                e               // else
+                        ] ]);
+
+                        return redo_if(ret);
+                }
+
+                return statements;
+        };
+
+        function redo_if_lambda(name, args, body) {
+                body = redo_if(body);
+                return [ this[0], name, args.slice(), body ];
+        };
+
+        function redo_if_block(statements) {
+                var out = [ this[0] ];
+                if (statements != null)
+                        out.push(redo_if(statements));
+                return out;
+        };
+
+        ast = w.with_walkers({
+                "defun": redo_if_lambda,
+                "function": redo_if_lambda,
+                "block": redo_if_block,
+                "splice": redo_if_block,
+                "toplevel": function(statements) {
+                        return [ this[0], redo_if(statements) ];
+                },
+                "try": function(t, c, f) {
+                        return [
+                                this[0],
+                                redo_if(t),
+                                c != null ? [ c[0], redo_if(c[1]) ] : null,
+                                f != null ? redo_if(f) : null
+                        ];
+                },
+                "with": function(expr, block) {
+                        return [ this[0], walk(expr), redo_if(block) ];
+                }
+        }, function() {
+                return walk(ast);
+        });
+
         return w.with_walkers({
                 "sub": function(expr, subscript) {
                         if (subscript[0] == "string") {

--- a/test/unit/compress/expected/ifreturn2.js
+++ b/test/unit/compress/expected/ifreturn2.js
@@ -1,0 +1,1 @@
+function y(a){return typeof a=="object"?a:null}function x(a){return typeof a=="object"?a:a===42?0:a*2}

--- a/test/unit/compress/test/ifreturn2.js
+++ b/test/unit/compress/test/ifreturn2.js
@@ -1,0 +1,16 @@
+function x(a) {
+    if (typeof a === 'object')
+        return a;
+
+    if (a === 42)
+        return 0;
+
+    return a * 2;
+}
+
+function y(a) {
+    if (typeof a === 'object')
+        return a;
+
+    return null;
+};

--- a/test/unit/scripts.js
+++ b/test/unit/scripts.js
@@ -17,30 +17,39 @@ function compress(code) {
 	return pro.gen_code(ast);
 };
 
-module.exports = nodeunit.testCase({
-	compress: function(test) {
-		var testDir = path.join(scriptsPath, "compress", "test");
-		var expectedDir = path.join(scriptsPath, "compress", "expected");
+var testDir = path.join(scriptsPath, "compress", "test");
+var expectedDir = path.join(scriptsPath, "compress", "expected");
 
-		var scripts = fs.readdirSync(testDir);
-		for (var i in scripts) {
-			var script = scripts[i];
-			testPath = path.join(testDir, script);
-			expectedPath = path.join(expectedDir, script);
-			var content = fs.readFileSync(testPath, 'utf-8');
-			var outputCompress = compress(content);
+function getTester(script) {
+	return function(test) {
+		var testPath = path.join(testDir, script);
+		var expectedPath = path.join(expectedDir, script);
+		var content = fs.readFileSync(testPath, 'utf-8');
+		var outputCompress = compress(content);
 
-			// Check if the noncompressdata is larger or same size as the compressed data
-			test.ok(content.length >= outputCompress.length);
+		// Check if the noncompressdata is larger or same size as the compressed data
+		test.ok(content.length >= outputCompress.length);
 
-			// Check that a recompress gives the same result
-			var outputReCompress = compress(content);
-			test.equal(outputCompress, outputReCompress);
+		// Check that a recompress gives the same result
+		var outputReCompress = compress(content);
+		test.equal(outputCompress, outputReCompress);
 
-			// Check if the compressed output is what is expected
-			var expected = fs.readFileSync(expectedPath, 'utf-8');
-			test.equal(outputCompress, expected.replace(/(\r?\n)+$/, ""));
-		}
+		// Check if the compressed output is what is expected
+		var expected = fs.readFileSync(expectedPath, 'utf-8');
+		test.equal(outputCompress, expected.replace(/(\r?\n)+$/, ""));
+
 		test.done();
+	};
+};
+
+var tests = {};
+
+var scripts = fs.readdirSync(testDir);
+for (var i in scripts) {
+	var script = scripts[i];
+	if (/\.js$/.test(script)) {
+		tests[script] = getTester(script);
 	}
-});
+}
+
+module.exports = nodeunit.testCase(tests);


### PR DESCRIPTION
I noticed a missing optimization UglifyJS could be performing.  Take the following example:

```
if (x) {
    return y;
}   
return foobar();
```

This is currently rewritten into:

```
if(x)return y;return foobar();
```

However, there's some potential for more minification.  It could instead be rewritten into:

```
return x?y:foobar();
```

Chained `if`s could really benefit:

```
if(a)return 1;
if(b)return 2;
if(c)return 3;
return 4;

// =>

return a?1:b?2:c?3:4;
```

`throw` statements can similarly be optimized:

```
if(a)throw a;
if(b)throw b;
throw new Error();

// =>

throw a?a:b?b:new Error;
```

I have fixed this problem in my `return-if2` branch.  A test case is included.
