### PR TITLE
Only a subset of space characters is problematic after `</script`, so use `[\t\n\f\r ]` instead of `\s`. 

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1225,7 +1225,7 @@ function gen_code(ast, options) {
         function encode_string(str) {
                 var ret = make_string(str, options.ascii_only);
                 if (options.inline_script)
-                        ret = ret.replace(/<\x2fscript([>\s])/gi, "<\\/script$1");
+                        ret = ret.replace(/<\x2fscript([>\t\n\f\r ])/gi, "<\\/script$1");
                 return ret;
         };
 

--- a/lib/process.js
+++ b/lib/process.js
@@ -1225,7 +1225,7 @@ function gen_code(ast, options) {
         function encode_string(str) {
                 var ret = make_string(str, options.ascii_only);
                 if (options.inline_script)
-                        ret = ret.replace(/<\x2fscript([>\t\n\f\r ])/gi, "<\\/script$1");
+                        ret = ret.replace(/<\x2fscript([>/\t\n\f\r ])/gi, "<\\/script$1");
                 return ret;
         };
 


### PR DESCRIPTION
Only a subset of space characters is problematic after `</script`, so use `[\t\n\f\r ]` instead of `\s`.

References:
- http://mathiasbynens.be/notes/etago
- http://www.whatwg.org/specs/web-apps/current-work/multipage/common-microsyntaxes.html#space-character
