### PR TITLE
Fix for #180 - parenthesize seqs as values of object literals and thrown values

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1365,7 +1365,7 @@ function gen_code(ast, options) {
                         return add_spaces(out);
                 },
                 "throw": function(expr) {
-                        return add_spaces([ "throw", make(expr) ]) + ";";
+                        return add_spaces([ "throw", parenthesize(expr,"seq") ]) + ";";
                 },
                 "new": function(ctor, args) {
                         args = args.length > 0 ? "(" + add_commas(MAP(args, make)) + ")" : "";
@@ -1513,7 +1513,7 @@ function gen_code(ast, options) {
                                                 // body in p[1][3] and type ("get" / "set") in p[2].
                                                 return indent(make_function(p[0], p[1][2], p[1][3], p[2]));
                                         }
-                                        var key = p[0], val = make(p[1]);
+                                        var key = p[0], val = parenthesize(p[1],"seq");
                                         if (options.quote_keys) {
                                                 key = encode_string(key);
                                         } else if ((typeof key == "number" || !beautify && +key + "" == key)


### PR DESCRIPTION
Fix for issue #180 - values of object literals and thrown values should be parenthesized if they're sequences
