### PR TITLE
compile conditional assigns to assign with ternary operand

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -563,6 +563,7 @@ function ast_mangle(ast, options) {
    - join consecutive var declarations
    - various optimizations for IFs:
      - if (cond) foo(); else bar();  ==>  cond?foo():bar();
+     - if (cond) a=foo() ==> a=cond?foo():a
      - if (cond) foo();  ==>  cond&&foo();
      - if (foo) return bar(); else return baz();  ==> return foo?bar():baz(); // also for throw
      - if (foo) return bar(); else something();  ==> {if(foo)return bar();something()}
@@ -615,7 +616,32 @@ function boolean_expr(expr) {
 
 function make_conditional(c, t, e) {
     var make_real_conditional = function() {
-        if (c[0] == "unary-prefix" && c[1] == "!") {
+        function justAssigns(a) { return a[0] == "assign"}
+        if (
+          justAssigns(t)
+          // if there's an else block, it must have the same target for assignment
+          && (!e || (justAssigns(e) && deepEquals(t[2], e[2]) && t[1] === e[1]))
+          // if there's no else block, the assignment target appears twice in the result
+          // and therefore it must not be longer than one byte
+          && (e || (t[2][0] == "name" && t[2][1].length == 1))) {
+            var target = t[2];
+            var ZERO_NODE = [ "num", 0 ];
+            var ONE_NODE = [ "num", 1 ];
+            var NO_OPS =
+              { "true": target
+              , "+": ZERO_NODE
+              , "-": ZERO_NODE
+              , "*": ONE_NODE
+              , "/": ONE_NODE
+              }
+            var t_val = t[3];
+            // if there's no else block, just do a no-op in case the condition isn't fullfilled
+            var e_val = e?e[3]:NO_OPS[t[1]];
+            // don't return the result if we need a no-op but can't find one
+            if (e_val)
+                return [ "assign", t[1], target, [ "conditional", c, t_val, e_val ] ];
+        // yes, not "else". fallthrough in case the operator has no neutral element.
+        } if (c[0] == "unary-prefix" && c[1] == "!") {
             return e ? [ "conditional", c[2], e, t ] : [ "binary", "||", c[2], t ];
         } else {
             return e ? [ "conditional", c, t, e ] : [ "binary", "&&", c, t ];
@@ -1757,6 +1783,28 @@ var MAP;
         MAP.at_top = function(val) { return new AtTop(val) };
         function AtTop(val) { this.v = val };
 })();
+
+function deepEquals(a, b) {
+        if (typeof a !== typeof b) return false;
+        switch (typeof a) {
+                case "object":
+                        var keys = Object.keys(a);
+                        var keysB = Object.keys(b);
+                        if (keys.length !== keysB.length) return false;
+                        for (var i=0; i<keys.length; i++) {
+                                var key = keys[i];
+                                if (keysB.indexOf(key) === -1) return false;
+                                if (!deepEquals(a[key], b[key])) return false;
+                        }
+                        return true;
+                case "array":
+                        if (a.length !== b.length) return false;
+                        for (var i=0; i<a.length; i++)
+                                if (!deepEquals(a[i], b[i])) return false;
+                        return true;
+        }
+        return a === b;
+}
 
 /* -----[ Exports ]----- */
 


### PR DESCRIPTION
This commit implements my suggestion from #193 and does even more. Some compilation examples:
(first line: original, second line: old compilation, third line: new compilation)

```
if(a)b=foo()
a&&(b=foo())
b=a?foo():b

if(a)b=foo();else b=bar()
a?b=foo():b=bar()
b=a?foo():bar()

if(a)b+=3
a&&(b+=3)
b+=a?3:0

if(a)b.c+=3
a&&(b.c+=3)
-

if(a)b.c+=3;else b.c+=4
a?b.c+=3:b.c+=4
b.c+=a?3:4
```

It reduces the size of minified jquery by 0,12% (116 bytes). However, it **increases**
the gzipped size of minified jquery by 26 bytes :( .
