### PR TITLE
Small fix to slice() to make it more robust and less confusing.

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -1278,7 +1278,7 @@ function array_to_hash(a) {
 };
 
 function slice(a, start) {
-        return Array.prototype.slice.call(a, start == null ? 0 : start);
+        return Array.prototype.slice.call(a, start || 0);
 };
 
 function characters(str) {


### PR DESCRIPTION
parameter start arrives 'undefined' or 'null', any falsy value should be zero
