### PR TITLE
Recognize various Unicode whitespace

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -189,7 +189,7 @@ var OPERATORS = array_to_hash([
         "||"
 ]);
 
-var WHITESPACE_CHARS = array_to_hash(characters(" \u00a0\n\r\t\f\u000b\u200b"));
+var WHITESPACE_CHARS = array_to_hash(characters(" \u00a0\n\r\t\f\u000b\u200b\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000"));
 
 var PUNC_BEFORE_EXPRESSION = array_to_hash(characters("[{}(,.;:"));
 

--- a/test/unit/compress/expected/whitespace.js
+++ b/test/unit/compress/expected/whitespace.js
@@ -1,0 +1,1 @@
+function id(a){return a}

--- a/test/unit/compress/test/whitespace.js
+++ b/test/unit/compress/test/whitespace.js
@@ -1,0 +1,21 @@
+function id(a) {
+  // Form-Feed
+  // Vertical Tab
+   // No-Break Space
+  ᠎// Mongolian Vowel Separator
+   // En quad
+   // Em quad
+   // En space
+   // Em space
+   // Three-Per-Em Space
+   // Four-Per-Em Space
+   // Six-Per-Em Space
+   // Figure Space
+   // Punctuation Space
+   // Thin Space
+   // Hair Space
+   // Narrow No-Break Space
+   // Medium Mathematical Space
+  　// Ideographic Space
+  return a;
+}


### PR DESCRIPTION
Parse Unicode characters allowed in browsers. For reference, see http://en.wikipedia.org/wiki/Space_(punctuation)#Spaces_in_Unicode
