### PR TITLE
documentation display correction: 

### DIFF
--- a/README.org
+++ b/README.org
@@ -137,7 +137,7 @@ following cases UglifyJS *doesn't touch* calls or instantiations of Array:
   // etc.
 #+END_SRC
 
-*** =obj.toString()= ==> =obj+“”=
+*** =obj.toString() ==> obj+“”=
 
 ** Install (NPM)
 


### PR DESCRIPTION
changed **\* =obj.toString()= ==> =obj+“”= to **\* =obj.toString() ==> obj+“”= to prevent strange appearance of "==>"
