### PR TITLE
binary op swap

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -648,9 +648,21 @@ function make_conditional(c, t, e) {
     var make_real_conditional = function() {
         if (c[0] == "unary-prefix" && c[1] == "!") {
             return e ? [ "conditional", c[2], e, t ] : [ "binary", "||", c[2], t ];
-        } else {
-            return e ? [ "conditional", c, t, e ] : [ "binary", "&&", c, t ];
         }
+        if (c[0] == "binary") {
+            var binOp = c[1];
+            var binOpSwaps = {
+                "<=": ">",
+                ">=": "<"
+            };
+            if (binOpSwaps[binOp] && e) {
+                c[1] = binOpSwaps[binOp];
+                var t_swap = t;
+                t = e;
+                e = t_swap;
+            }
+        }
+        return e ? [ "conditional", c, t, e ] : [ "binary", "&&", c, t ];
     };
     // shortcut the conditional if the expression has a constant value
     return when_constant(c, function(ast, val){

--- a/lib/process.js
+++ b/lib/process.js
@@ -644,25 +644,29 @@ function boolean_expr(expr) {
                );
 };
 
+function maybeBinOpSwap(node) {
+    if (node[1][0] == "binary") {
+        var binOp = node[1][1];
+        var binOpSwaps = {
+            "<=": ">",
+            ">=": "<"
+        };
+        if (binOpSwaps[binOp] && node[3]) {
+            node[1][1] = binOpSwaps[binOp];
+            var t_swap = node[2];
+            node[2] = node[3];
+            node[3] = t_swap;
+        }
+    }
+    return node;
+};
+
 function make_conditional(c, t, e) {
     var make_real_conditional = function() {
         if (c[0] == "unary-prefix" && c[1] == "!") {
             return e ? [ "conditional", c[2], e, t ] : [ "binary", "||", c[2], t ];
         }
-        if (c[0] == "binary") {
-            var binOp = c[1];
-            var binOpSwaps = {
-                "<=": ">",
-                ">=": "<"
-            };
-            if (binOpSwaps[binOp] && e) {
-                c[1] = binOpSwaps[binOp];
-                var t_swap = t;
-                t = e;
-                e = t_swap;
-            }
-        }
-        return e ? [ "conditional", c, t, e ] : [ "binary", "&&", c, t ];
+        return e ? maybeBinOpSwap([ "conditional", c, t, e ]) : [ "binary", "&&", c, t ];
     };
     // shortcut the conditional if the expression has a constant value
     return when_constant(c, function(ast, val){
@@ -1214,7 +1218,7 @@ function ast_squeeze(ast, options) {
                 }
                 if (empty(e) && empty(t))
                         return [ "stat", c ];
-                var ret = [ "if", c, t, e ];
+                var ret = maybeBinOpSwap([ "if", c, t, e ]);
                 if (t[0] == "if" && empty(t[3]) && empty(e)) {
                         ret = best_of(ret, walk([ "if", [ "binary", "&&", c, t[1] ], t[2] ]));
                 }

--- a/lib/process.js
+++ b/lib/process.js
@@ -651,7 +651,7 @@ function maybeBinOpSwap(node) {
             "<=": ">",
             ">=": "<"
         };
-        if (binOpSwaps[binOp] && node[3]) {
+        if (binOp in binOpSwaps && node[3] != null) {
             node[1][1] = binOpSwaps[binOp];
             var t_swap = node[2];
             node[2] = node[3];

--- a/lib/process.js
+++ b/lib/process.js
@@ -1219,6 +1219,8 @@ function ast_squeeze(ast, options) {
                 if (empty(e) && empty(t))
                         return [ "stat", c ];
                 var ret = maybeBinOpSwap([ "if", c, t, e ]);
+                t = ret[2];
+                e = ret[3];
                 if (t[0] == "if" && empty(t[3]) && empty(e)) {
                         ret = best_of(ret, walk([ "if", [ "binary", "&&", c, t[1] ], t[2] ]));
                 }


### PR DESCRIPTION
Example (input, current compilation, new compilation):

```
if (a <= 5) foo(); else bar();
a<=5?foo():bar()
a>5?foo():bar()
```

Doesn't have much effect, but it's just a little change.
