### PR TITLE
compile `a=a+b` to `a+=b` and so on

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1318,7 +1318,18 @@ function ast_squeeze(ast, options) {
                             case "false": return [ "unary-prefix", "!", [ "num", 1 ]];
                         }
                 },
-                "while": _do_while
+                "while": _do_while,
+                "assign": function(op, lvalue, rvalue) {
+                        lvalue = walk(lvalue);
+                        rvalue = walk(rvalue);
+                        var okOps = "+,-,/,*,%,>>,<<,>>>,|,^,&".split(",");
+                        if (op === true && lvalue[0] === "name" && rvalue[0] === "binary" &&
+                            ~okOps.indexOf(rvalue[1]) && rvalue[2][0] === "name" &&
+                            rvalue[2][1] === lvalue[1]) {
+                                return [ this[0], rvalue[1], lvalue, rvalue[3] ]
+                        }
+                        return [ this[0], op, lvalue, rvalue ];
+                }
         }, function() {
                 for (var i = 0; i < 2; ++i) {
                         ast = prepare_ifs(ast);

--- a/lib/process.js
+++ b/lib/process.js
@@ -1322,7 +1322,7 @@ function ast_squeeze(ast, options) {
                 "assign": function(op, lvalue, rvalue) {
                         lvalue = walk(lvalue);
                         rvalue = walk(rvalue);
-                        var okOps = "+,-,/,*,%,>>,<<,>>>,|,^,&".split(",");
+                        var okOps = [ '+', '-', '/', '*', '%', '>>', '<<', '>>>', '|', '^', '&' ];
                         if (op === true && lvalue[0] === "name" && rvalue[0] === "binary" &&
                             ~okOps.indexOf(rvalue[1]) && rvalue[2][0] === "name" &&
                             rvalue[2][1] === lvalue[1]) {


### PR DESCRIPTION
Compile `<A> = <A> <OP> <B>` to `<A> <OP>= <A>` when:
- `<A>` is a simple name (we don't want to change getter side effects)
- the resulting assignment operator is valid
