### PR TITLE
Add parens to constructor args (for new expressions)

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1556,7 +1556,9 @@ function gen_code(ast, options) {
                         return add_spaces([ "throw", make(expr) ]) + ";";
                 },
                 "new": function(ctor, args) {
-                        args = args.length > 0 ? "(" + add_commas(MAP(args, make)) + ")" : "";
+                        args = args.length > 0 ? "(" + add_commas(MAP(args, function(expr){
+                                return parenthesize(expr, "seq");
+                        })) + ")" : "";
                         return add_spaces([ "new", parenthesize(ctor, "seq", "binary", "conditional", "assign", function(expr){
                                 var w = ast_walker(), has_call = {};
                                 try {


### PR DESCRIPTION
"new ctor((x, y))" was not being re-constructed correctly.
