### PR TITLE
Added null as a constant.

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -686,6 +686,7 @@ var when_constant = (function(){
                         switch (expr[1]) {
                             case "true": return true;
                             case "false": return false;
+                            case "null": return null;
                         }
                         break;
                     case "unary-prefix":


### PR DESCRIPTION
This makes code like this compress:

``` javascript
if (true === null) {
    stuff();
}
```

to nothing, which is better than `!0===null&&stuff()`.
