### PR TITLE
Parenthesize function expressions.

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1353,7 +1353,8 @@ var DOT_CALL_NO_PARENS = jsp.array_to_hash([
         "dot",
         "sub",
         "call",
-        "regexp"
+        "regexp",
+        "defun"
 ]);
 
 function make_string(str, ascii_only) {
@@ -1788,7 +1789,8 @@ function gen_code(ast, options) {
                         out += " " + make_name(name);
                 }
                 out += "(" + add_commas(MAP(args, make_name)) + ")";
-                return add_spaces([ out, make_block(body) ]);
+                out = add_spaces([ out, make_block(body) ]);
+                return needs_parens(this) ? "(" + out + ")" : out;
         };
 
         function must_has_semicolon(node) {


### PR DESCRIPTION
Anonymous and named function expressions get parens:
(function(){}) -> (function(){})
(function f(){}) -> (function f(){})

But function declarations get left alone:
function f(){} -> function(){}
