### PR TITLE
Parenthesize object literals with no properties.

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1698,8 +1698,9 @@ function gen_code(ast, options) {
                         return hash + "[" + make(subscript) + "]";
                 },
                 "object": function(props) {
+                        var obj_needs_parens = needs_parens(this);
                         if (props.length == 0)
-                                return "{}";
+                                return obj_needs_parens ? "({})" : "{}";
                         var out = "{" + newline + with_indent(function(){
                                 return MAP(props, function(p){
                                         if (p.length == 3) {
@@ -1721,7 +1722,7 @@ function gen_code(ast, options) {
                                                                  : [ key + ":", val ]));
                                 }).join("," + newline);
                         }) + newline + indent("}");
-                        return needs_parens(this) ? "(" + out + ")" : out;
+                        return obj_needs_parens ? "(" + out + ")" : out;
                 },
                 "regexp": function(rx, mods) {
                         return "/" + rx + "/" + mods;


### PR DESCRIPTION
I commented on this previously here: https://github.com/mishoo/UglifyJS/commit/f12f00e75224b49fee182845934d0ce45fa19a99#commitcomment-598520

Since I had to implement the fix in my code anyway, I figured I'd just make the pull request also.
