### PR TITLE
Don't insert semicolons before multi-line strings.

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -291,12 +291,12 @@ function tokenizer($TEXT) {
 
         function peek() { return S.text.charAt(S.pos); };
 
-        function next(signal_eof) {
+        function next(signal_eof, in_string) {
                 var ch = S.text.charAt(S.pos++);
                 if (signal_eof && !ch)
                         throw EX_EOF;
                 if (ch == "\n") {
-                        S.newline_before = true;
+                        S.newline_before = S.newline_before || !in_string;
                         ++S.line;
                         S.col = 0;
                 } else {
@@ -393,8 +393,8 @@ function tokenizer($TEXT) {
                 }
         };
 
-        function read_escaped_char() {
-                var ch = next(true);
+        function read_escaped_char(in_string) {
+                var ch = next(true, in_string);
                 switch (ch) {
                     case "n" : return "\n";
                     case "r" : return "\r";
@@ -442,7 +442,7 @@ function tokenizer($TEXT) {
                                                 return false;
                                         });
                                         if (octal_len > 0) ch = String.fromCharCode(parseInt(ch, 8));
-                                        else ch = read_escaped_char();
+                                        else ch = read_escaped_char(true);
                                 }
                                 else if (ch == quote) break;
                                 ret += ch;


### PR DESCRIPTION
(Escaped) newlines in multi-line strings don't count as
newlines for semicolon insertion purposes.

<pre>
$ cat test.js
function x() { return 'abc\
  ';}
</pre>


Before patch:

<pre>
$ node -e "require('./lib/process').gen_code(require('./lib/parse-js').parse(require('fs').readFileSync('test.js', 'utf-8')))"
function x(){return;"abc  "}
</pre>


After patch:

<pre>
$ node -e "require('./lib/process').gen_code(require('./lib/parse-js').parse(require('fs').readFileSync('test.js', 'utf-8')))"
function x(){return"abc  "}
</pre>
