### PR TITLE
Provide global install info on npm for using command-line tool

### DIFF
--- a/README.html
+++ b/README.html
@@ -331,7 +331,8 @@ following cases UglifyJS <b>doesn't touch</b> calls or instantiations of Array:
 
 <p>
 UglifyJS is now available through NPM &mdash; <code>npm install uglify-js</code> should do
-the job.
+the job. If you intend to use the command-line tool, install the package globally:
+<code>npm install uglify-js -g</code>
 </p>
 </div>
 

--- a/README.org
+++ b/README.org
@@ -142,7 +142,8 @@ following cases UglifyJS *doesn't touch* calls or instantiations of Array:
 ** Install (NPM)
 
 UglifyJS is now available through NPM --- =npm install uglify-js= should do
-the job.
+the job. If you intend to use the command-line tool, install the package globally: 
+=npm install uglify-js -g=
 
 ** Install latest code from GitHub
 


### PR DESCRIPTION
When using npm install uglify-js without a -g, the command line tool doesn't appear. I made a quick note of this behavior for people that aren't as familiar with npm/node.
