### PR TITLE
Respect embed_tokens setting for object keys

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -1141,11 +1141,15 @@ function parse($TEXT, exigent_mode, embed_tokens) {
 
         function as_property_name() {
                 switch (S.token.type) {
+                    case "name":
+                    case "operator":
+                    case "keyword":
+                    case "atom":
                     case "num":
                     case "string":
-                        return prog1(S.token.value, next);
+                        return prog1(embed_tokens ? S.token : S.token.value, next);
                 }
-                return as_name();
+                unexpected();
         };
 
         function as_name() {
@@ -1155,9 +1159,8 @@ function parse($TEXT, exigent_mode, embed_tokens) {
                     case "keyword":
                     case "atom":
                         return prog1(S.token.value, next);
-                    default:
-                        unexpected();
                 }
+                unexpected();
         };
 
         function subscripts(expr, allow_calls) {


### PR DESCRIPTION
The tokens for object keys were thrown away even if the embed_tokens
setting was set to true. This change allows to use the comments_before
of tokens to parse documentation on object keys.
