### PR TITLE
Fixed parse error position: start line number and column number from 1.

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -254,9 +254,9 @@ function parse_js_number(num) {
 
 function JS_Parse_Error(message, line, col, pos) {
         this.message = message;
-        this.line = line;
-        this.col = col;
-        this.pos = pos;
+        this.line = line + 1;
+        this.col = col + 1;
+        this.pos = pos + 1;
         this.stack = new Error().stack;
 };
 


### PR DESCRIPTION
For example:

``` javascript
var
x + 1;
```

In current version UglifyJS error line is 1, in Node.js error line is 2.
