### PR TITLE
Unsafe: call RegExp, Function, Error builtin constructors without new

### DIFF
--- a/lib/squeeze-more.js
+++ b/lib/squeeze-more.js
@@ -39,6 +39,8 @@ function ast_squeeze_more(ast) {
                                         } else {
                                                 return walk([ "call", [ "name", "Object" ], args ]);
                                         }
+                                } else if (ctor[1] == "RegExp" && !scope.has("RegExp")) {
+                                        return walk([ "call", [ "name", "RegExp" ], args]);
                                 }
                         }
                 },

--- a/lib/squeeze-more.js
+++ b/lib/squeeze-more.js
@@ -39,8 +39,8 @@ function ast_squeeze_more(ast) {
                                         } else {
                                                 return walk([ "call", [ "name", "Object" ], args ]);
                                         }
-                                } else if (ctor[1] == "RegExp" && !scope.has("RegExp")) {
-                                        return walk([ "call", [ "name", "RegExp" ], args]);
+                                } else if ((ctor[1] == "RegExp" || ctor[1] == "Error") && !scope.has(ctor[1])) {
+                                        return walk([ "call", [ "name", ctor[1] ], args]);
                                 }
                         }
                 },

--- a/lib/squeeze-more.js
+++ b/lib/squeeze-more.js
@@ -39,7 +39,7 @@ function ast_squeeze_more(ast) {
                                         } else {
                                                 return walk([ "call", [ "name", "Object" ], args ]);
                                         }
-                                } else if ((ctor[1] == "RegExp" || ctor[1] == "Error") && !scope.has(ctor[1])) {
+                                } else if ((ctor[1] == "RegExp" || ctor[1] == "Function" || ctor[1] == "Error") && !scope.has(ctor[1])) {
                                         return walk([ "call", [ "name", ctor[1] ], args]);
                                 }
                         }


### PR DESCRIPTION
``` javascript
new RegExp()   => RegExp()
new Error()    => Error()
new Function() => Function()
```
