### PR TITLE
Remove whitespace in #! line

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 // -*- js -*-
 
 global.sys = require(/^v0\.[012]/.test(process.version) ? "sys" : "util");


### PR DESCRIPTION
I just discovered a bug in npm where a space between the `#!` and the `/usr/bin/env` is
causing it to not realize that this is a node program when it's installing on windows.

As a result, it doesn't set up the batch file properly.

I'm fixing the bug in npm, but it would be very helpful if you could remove the space here,
and republish as soon as you get a chance.  Thanks!
