### PR TITLE
Remove calls to console.*

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -286,7 +286,7 @@ function squeeze_it(code) {
                         ast = time_it("lift", function(){ return pro.ast_lift_variables(ast); });
                 }
                 if (options.no_console) {
-                        ast = time_it("lift", function(){ return pro.ast_squeeze_console(ast); });
+                        ast = time_it("console", function(){ return pro.ast_squeeze_console(ast); });
                 }
                 if (options.mangle) ast = time_it("mangle", function(){
                         return pro.ast_mangle(ast, {

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -15,6 +15,7 @@ var options = {
         squeeze: true,
         make_seqs: true,
         dead_code: true,
+        no_console: false,
         verbose: false,
         show_copyright: true,
         out_same_file: false,
@@ -75,6 +76,9 @@ out: while (args.length > 0) {
                 break;
             case "--no-dead-code":
                 options.dead_code = false;
+                break;
+            case "--no-console":
+                options.no_console = true;
                 break;
             case "--no-copyright":
             case "-nc":
@@ -280,6 +284,9 @@ function squeeze_it(code) {
                 var ast = time_it("parse", function(){ return jsp.parse(code); });
                 if (options.lift_vars) {
                         ast = time_it("lift", function(){ return pro.ast_lift_variables(ast); });
+                }
+                if (options.no_console) {
+                        ast = time_it("lift", function(){ return pro.ast_squeeze_console(ast); });
                 }
                 if (options.mangle) ast = time_it("mangle", function(){
                         return pro.ast_mangle(ast, {

--- a/lib/process.js
+++ b/lib/process.js
@@ -2006,4 +2006,6 @@ exports.split_lines = split_lines;
 exports.MAP = MAP;
 
 // keep this last!
-exports.ast_squeeze_more = require("./squeeze-more").ast_squeeze_more;
+var more = require("./squeeze-more");
+exports.ast_squeeze_more = more.ast_squeeze_more;
+exports.ast_squeeze_console = more.ast_squeeze_console;

--- a/lib/squeeze-more.js
+++ b/lib/squeeze-more.js
@@ -66,4 +66,24 @@ function ast_squeeze_more(ast) {
         });
 };
 
+function ast_squeeze_console(ast) {
+        var w = pro.ast_walker(), walk = w.walk, scope;
+         return w.with_walkers({
+                "stat": function(stmt) {
+                        if(stmt[0] === "call" && stmt[1][0] == "dot" && stmt[1][1] instanceof Array && stmt[1][1][0] == 'name' && stmt[1][1][1] == "console") {
+                                return ["block"];
+                        }
+                        return ["stat", walk(stmt)];
+                },
+                "call": function(expr, args) {
+                        if (expr[0] == "dot" && expr[1] instanceof Array && expr[1][0] == 'name' && expr[1][1] == "console") {
+                                return ["atom", "0"];
+                        }
+                }
+        }, function() {
+                return walk(ast);
+        });
+};
+
 exports.ast_squeeze_more = ast_squeeze_more;
+exports.ast_squeeze_console = ast_squeeze_console;

--- a/test/unit/compress/expected/console.js
+++ b/test/unit/compress/expected/console.js
@@ -1,0 +1,1 @@
+var f=function(a,b,c){return a+b+c}

--- a/test/unit/compress/test/console.js
+++ b/test/unit/compress/test/console.js
@@ -1,0 +1,3 @@
+console.log("test")
+
+var f = function(a, b, c){console.log(a,b,c);return a + b + c;};

--- a/test/unit/scripts.js
+++ b/test/unit/scripts.js
@@ -9,11 +9,14 @@ var Script = process.binding('evals').Script;
 
 var scriptsPath = __dirname;
 
-function compress(code) {
+function compress(code, squeezeConsole) {
 	var ast = jsp.parse(code);
 	ast = pro.ast_mangle(ast);
+	if(squeezeConsole) {
+		ast = pro.ast_squeeze_console(ast);
+	}
 	ast = pro.ast_squeeze(ast, { no_warnings: true });
-        ast = pro.ast_squeeze_more(ast);
+	ast = pro.ast_squeeze_more(ast);
 	return pro.gen_code(ast);
 };
 
@@ -25,13 +28,13 @@ function getTester(script) {
 		var testPath = path.join(testDir, script);
 		var expectedPath = path.join(expectedDir, script);
 		var content = fs.readFileSync(testPath, 'utf-8');
-		var outputCompress = compress(content);
+		var outputCompress = compress(content, script==="console.js");
 
 		// Check if the noncompressdata is larger or same size as the compressed data
 		test.ok(content.length >= outputCompress.length);
 
 		// Check that a recompress gives the same result
-		var outputReCompress = compress(content);
+		var outputReCompress = compress(content, script==="console.js");
 		test.equal(outputCompress, outputReCompress);
 
 		// Check if the compressed output is what is expected


### PR DESCRIPTION
This change removes calls to console.\* statements as requested in #124 (I couldn't get this code to attach to that issue...)

It does so by replacing statements that call `console` methods with an empty block to be removed later by the squeeze function. 

The caveat is that it only fully removes console function calls if they are executed as statements. If the calls are made elsewhere in the tree then they will just be replaced with 0. For example, the following boolean expression:

```
console.log("a") && console.log("b")
```

will be compressed to:

```
0&&0
```

Also, the function arguments will be removed so users should be aware that if an argument is a function call, it won't be executed. For example, the `foo` function call will be totally removed in the following example:

```
console.log("this is bad", foo())
```

This can be executed from the commandline by adding the `--no-console` flag
