### PR TITLE
Test local file instead of npm installed version

### DIFF
--- a/test/unit/scripts.js
+++ b/test/unit/scripts.js
@@ -1,5 +1,5 @@
 var fs = require('fs'),
-	uglify = require('uglify-js'),
+	uglify = require('../../uglify-js'),
 	jsp = uglify.parser,
 	nodeunit = require('nodeunit'),
 	path = require('path'),


### PR DESCRIPTION
`require("uglify-js")` loads the module from npm path instead of the local file.
So I changed it to `require("../../uglify-js")`
