### PR TITLE
Remove parens from getter/setter

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1727,7 +1727,7 @@ function gen_code(ast, options) {
                                         if (p.length == 3) {
                                                 // getter/setter.  The name is in p[0], the arg.list in p[1][2], the
                                                 // body in p[1][3] and type ("get" / "set") in p[2].
-                                                return indent(make_function(p[0], p[1][2], p[1][3], p[2]));
+                                                return indent(make_function(p[0], p[1][2], p[1][3], p[2], true));
                                         }
                                         var key = p[0], val = parenthesize(p[1], "seq");
                                         if (options.quote_keys) {
@@ -1804,14 +1804,14 @@ function gen_code(ast, options) {
                 return make(th);
         };
 
-        function make_function(name, args, body, keyword) {
+        function make_function(name, args, body, keyword, omit_parens) {
                 var out = keyword || "function";
                 if (name) {
                         out += " " + make_name(name);
                 }
                 out += "(" + add_commas(MAP(args, make_name)) + ")";
                 out = add_spaces([ out, make_block(body) ]);
-                return needs_parens(this) ? "(" + out + ")" : out;
+                return !omit_parens && needs_parens(this) ? "(" + out + ")" : out;
         };
 
         function must_has_semicolon(node) {


### PR DESCRIPTION
One more for #117 (gen_code adds unnecessary parentheses)

getter / setter are enclosed with parentheses. `this` is global in `make_function` (not called with `apply`), so I use a new argument to override the call of `need_parens`.
