### PR TITLE
Keep strings from object literal keys in the AST

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -1135,6 +1135,9 @@ function parse($TEXT, exigent_mode, embed_tokens) {
                                 a.push([ as_name(), function_(false), name ]);
                         } else {
                                 expect(":");
+                                if (type == "string") {
+                                        name = [ "string", name ];
+                                }
                                 a.push([ name, expression(false) ]);
                         }
                 }

--- a/lib/process.js
+++ b/lib/process.js
@@ -1733,6 +1733,9 @@ function gen_code(ast, options) {
                                                 return indent(make_function(p[0], p[1][2], p[1][3], p[2], true));
                                         }
                                         var key = p[0], val = parenthesize(p[1], "seq");
+                                        if (key[0] == "string") {
+                                                key = key[1];
+                                        }
                                         if (options.quote_keys) {
                                                 key = encode_string(key);
                                         } else if ((typeof key == "number" || !beautify && +key + "" == key)

--- a/test/testparser.js
+++ b/test/testparser.js
@@ -1,11 +1,10 @@
 #! /usr/bin/env node
 
 var parseJS = require("../lib/parse-js");
-var sys = require("sys");
 
 // write debug in a very straightforward manner
 var debug = function(){
-        sys.log(Array.prototype.slice.call(arguments).join(', '));
+	console.log(Array.prototype.slice.call(arguments).join(', '));
 };
 
 ParserTestSuite(function(i, input, desc){


### PR DESCRIPTION
It may be valuable to be able to tell the difference between these two
constructs even though their meanings are identical.
{'foo': 1}
and
{foo: 1}

For instance there are some very powerful minifications that can be made
with careful site-wide passes. Also if you are using uglify's AST for
linting this comes in handy.
