### PR TITLE
mangle `this` references when advantageous

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -281,14 +281,21 @@ function squeeze_it(code) {
                 if (options.lift_vars) {
                         ast = time_it("lift", function(){ return pro.ast_lift_variables(ast); });
                 }
-                if (options.mangle) ast = time_it("mangle", function(){
-                        return pro.ast_mangle(ast, {
-                                toplevel     : options.mangle_toplevel,
-                                defines      : options.defines,
-                                except       : options.reserved_names,
-                                no_functions : options.no_mangle_functions
+                if (options.mangle) {
+                        ast = time_it("grab_this", function(){
+                                return pro.ast_grab_this(ast, {
+                                        flatten_bind : options.unsafe,
+                                })
                         });
-                });
+                        ast = time_it("mangle", function(){
+                                return pro.ast_mangle(ast, {
+                                        toplevel     : options.mangle_toplevel,
+                                        defines      : options.defines,
+                                        except       : options.reserved_names,
+                                        no_functions : options.no_mangle_functions
+                                })
+                        });
+                }
                 if (options.squeeze) ast = time_it("squeeze", function(){
                         ast = pro.ast_squeeze(ast, {
                                 make_seqs  : options.make_seqs,

--- a/lib/process.js
+++ b/lib/process.js
@@ -910,49 +910,62 @@ function ast_grab_this(ast, options) {
         function many_this(body) {
                 var w = ast_walker();
                 var needed = 4;
+
+                function walk() {
+                        return w.walk.apply(this, arguments);
+                }
+                function bail() {
+                        w.walk = function() {
+                                return MAP.skip;
+                        };
+                }
+
                 if (body.length && body[0][0] == "var") {
                         // if this function starts with a var, then 3 this refs will be sufficient for reductions in
                         // code
                         --needed;
                 }
 
-                try {
-                        w.with_walkers({
-                                "function": function() { return [] },
-                                "defun": function() { return [] },
-                                "name": function(name) {
-                                        if (name == "this") {
-                                                if (!--needed) {
-                                                        throw 1; // bail early
-                                                }
+                w.with_walkers({
+                        "function": function() { MAP.skip },
+                        "defun": function() { MAP.skip },
+                        "name": function(name) {
+                                if (name == "this") {
+                                        if (--needed <= 0) {
+                                                bail();
                                         }
-                                },
-                                "call": function(expr, args) {
-                                        if (flatten_bind && args.length && args[0][0] == "name" && args[0][1] == "this") {
-                                                if (expr[0] == "dot" && expr[1][0] == "function" && expr[2] == "bind") {
-                                                        if (!--needed) {
-                                                                // count "bind" towards our "this" count since it will go away
-                                                                throw 1;
+                                }
+                        },
+                        "call": function(expr, args) {
+                                if (flatten_bind && args.length && args[0][0] == "name" && args[0][1] == "this") {
+                                        if (expr[0] == "dot" && expr[1][0] == "function" && expr[2] == "bind") {
+                                                if (args.length == 1) {
+                                                        // count "bind" towards our "this" count since it
+                                                        // will go away in the case only context is
+                                                        // bound
+                                                        if (--needed <= 0) {
+                                                                bail();
                                                         }
-                                                        MAP(expr[1][3], w.walk);
-                                                        MAP(args, w.walk);
-                                                        return [];
                                                 }
+                                                // DO descend into the function because the bound
+                                                // context will be reused
+                                                MAP(expr[1][3], walk);
+                                                MAP(args, walk);
+                                                return MAP.skip;
                                         }
-                                },
-                        }, function() {
-                                MAP(body, w.walk);
-                        });
-                } catch (err) {
-                        if (!needed) {
-                                return true;
-                        }
-                }
-                return false;
+                                }
+                        },
+                }, function() {
+                        MAP(body, walk);
+                });
+                return needed <= 0;
         }
 
         function do_body(body) {
-                var should_grab = many_this(body);
+                var should_grab = !body.scope.uses_with && !body.scope.uses_eval && many_this(body);
+                if (HOP(body.scope.refs, that)) {
+                        throw new Error('Found reference to `' + that + '` in source.');
+                }
                 var _got_this = got_this;
                 if (should_grab) {
                         got_this = true;
@@ -974,9 +987,6 @@ function ast_grab_this(ast, options) {
                 },
                 "function": function(name, args, body) {
                         return [ this[0], name, args, do_body(body) ];
-                },
-                "toplevel": function(body) {
-                        return [ this[0], do_body(body) ];
                 },
                 "name": function(name) {
                         if (name == "this" && got_this) {

--- a/lib/process.js
+++ b/lib/process.js
@@ -910,7 +910,7 @@ function ast_grab_this(ast, options) {
         function many_this(body) {
                 var w = ast_walker();
                 var needed = 4;
-                if (body[0][0] == "var") {
+                if (body.length && body[0][0] == "var") {
                         // if this function starts with a var, then 3 this refs will be sufficient for reductions in
                         // code
                         --needed;

--- a/lib/process.js
+++ b/lib/process.js
@@ -901,6 +901,108 @@ function for_side_effects(ast, handler) {
         });
 };
 
+function ast_grab_this(ast, options) {
+        var w = ast_walker(), got_this = false;
+        var that = "mangle_my_this_ref__";
+        var flatten_bind = options && options.flatten_bind;
+
+        // returns true if there are 4 or more references to "this" in this function.
+        function many_this(body) {
+                var w = ast_walker();
+                var needed = 4;
+                if (body[0][0] == "var") {
+                        // if this function starts with a var, then 3 this refs will be sufficient for reductions in
+                        // code
+                        --needed;
+                }
+
+                try {
+                        w.with_walkers({
+                                "function": function() { return [] },
+                                "defun": function() { return [] },
+                                "name": function(name) {
+                                        if (name == "this") {
+                                                if (!--needed) {
+                                                        throw 1; // bail early
+                                                }
+                                        }
+                                },
+                                "call": function(expr, args) {
+                                        if (flatten_bind && args.length && args[0][0] == "name" && args[0][1] == "this") {
+                                                if (expr[0] == "dot" && expr[1][0] == "function" && expr[2] == "bind") {
+                                                        if (!--needed) {
+                                                                // count "bind" towards our "this" count since it will go away
+                                                                throw 1;
+                                                        }
+                                                        MAP(expr[1][3], w.walk);
+                                                        MAP(args, w.walk);
+                                                        return [];
+                                                }
+                                        }
+                                },
+                        }, function() {
+                                MAP(body, w.walk);
+                        });
+                } catch (err) {
+                        if (!needed) {
+                                return true;
+                        }
+                }
+                return false;
+        }
+
+        function do_body(body) {
+                var should_grab = many_this(body);
+                var _got_this = got_this;
+                if (should_grab) {
+                        got_this = true;
+                        body = MAP(body, w.walk);
+                        body.unshift([ "var", [
+                                [ that, [ "name", "this"] ]
+                        ]]);
+                } else {
+                        got_this = false;
+                        body = MAP(body, w.walk);
+                }
+                got_this = _got_this;
+                return body;
+        }
+
+        return w.with_walkers({
+                "defun": function(name, args, body) {
+                        return [ this[0], name, args, do_body(body) ];
+                },
+                "function": function(name, args, body) {
+                        return [ this[0], name, args, do_body(body) ];
+                },
+                "toplevel": function(body) {
+                        return [ this[0], do_body(body) ];
+                },
+                "name": function(name) {
+                        if (name == "this" && got_this) {
+                                return [ "name", that ];
+                        }
+                        return [ "name", name ];
+                },
+                "call": function(expr, args) {
+                        if (flatten_bind && got_this && args.length && args[0][0] == "name" && args[0][1] == "this") {
+                                if (expr[0] == "dot" && expr[1][0] == "function" && expr[2] == "bind") {
+                                        var fn = expr[1];
+                                        fn = [ "function", fn[1], fn[2], MAP(fn[3], w.walk) ];
+                                        args = MAP(args, w.walk);
+                                        if (args.length == 1) {
+                                                return fn;
+                                        } else {
+                                                return [ "call", [ "dot", fn, "bind" ], args ];
+                                        }
+                                }
+                        }
+                },
+        }, function(){
+                return w.walk(ast_add_scope(ast));
+        });
+};
+
 function ast_lift_variables(ast) {
         var w = ast_walker(), walk = w.walk, scope;
         function do_body(body, env) {
@@ -2000,6 +2102,7 @@ var MAP;
 exports.ast_walker = ast_walker;
 exports.ast_mangle = ast_mangle;
 exports.ast_squeeze = ast_squeeze;
+exports.ast_grab_this = ast_grab_this;
 exports.ast_lift_variables = ast_lift_variables;
 exports.gen_code = gen_code;
 exports.ast_add_scope = ast_add_scope;


### PR DESCRIPTION
By memoizing `this` in a variable it can be mangled just like other variables.

With this same technique we can also remove local calls to bind in most cases (unsafe mode only).

This yields significant savings in most OO code.
