### PR TITLE
Fix issues #162 and #271

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -486,10 +486,10 @@ function tokenizer($TEXT) {
         };
 
         function read_name() {
-                var backslash = false, name = "", ch;
+                var backslash = false, name = "", ch, escaped = false, hex;
                 while ((ch = peek()) != null) {
                         if (!backslash) {
-                                if (ch == "\\") backslash = true, next();
+                                if (ch == "\\") escaped = backslash = true, next();
                                 else if (is_identifier_char(ch)) name += next();
                                 else break;
                         }
@@ -500,6 +500,10 @@ function tokenizer($TEXT) {
                                 name += ch;
                                 backslash = false;
                         }
+                }
+                if (HOP(KEYWORDS, name) && escaped) {
+                        hex = name.charCodeAt(0).toString(16).toUpperCase();
+                        name = "\\u" + "0000".substr(hex.length) + hex + name.slice(1);
                 }
                 return name;
         };


### PR DESCRIPTION
Fixes issues #162 and #271 by modifying the tokenizer so that reading a word that is an escaped keyword results in its first character being replaced by an equivalent Unicode escape sequence.
