### PR TITLE
Implement the idea from issue #325

### DIFF
--- a/lib/squeeze-more.js
+++ b/lib/squeeze-more.js
@@ -45,6 +45,10 @@ function ast_squeeze_more(ast) {
                         }
                 },
                 "call": function(expr, args) {
+                        if (expr[0] == "dot" && expr[1][0] == "string" && args.length == 1
+                            && (args[0][1] > 0 && expr[2] == "substring" || expr[2] == "substr")) {
+                                return [ "call", [ "dot", expr[1], "slice"], args];
+                        }
                         if (expr[0] == "dot" && expr[2] == "toString" && args.length == 0) {
                                 // foo.toString()  ==>  foo+""
                                 return [ "binary", "+", expr[1], [ "string", "" ]];


### PR DESCRIPTION
Implements the idea from issue #325 i.e. an unsafe transformation of calls to the `substr` and `substring` methods on a string literal into equivalent calls to the `slice` method.
