### PR TITLE
Support for license comments /*! license */

### DIFF
--- a/README.html
+++ b/README.html
@@ -449,6 +449,11 @@ Supported options:
   etc.).  If you pass this it will discard it.
 
 </li>
+<li><code>-nl</code> or <code>--no-licenses</code> &mdash; by default, <code>uglifyjs</code> will keep the text
+  marked /*! */ in the generated code (assumed to be license information
+  etc.).  If you pass this it will discard it.
+
+</li>
 <li><code>-o filename</code> or <code>--output filename</code> &mdash; put the result in <code>filename</code>.  If
   this isn't given, the result goes to standard output (or see next one).
 

--- a/README.org
+++ b/README.org
@@ -224,6 +224,10 @@ Supported options:
   comment tokens in the generated code (assumed to be copyright information
   etc.).  If you pass this it will discard it.
 
+- =-nl= or =--no-licenses= --- by default, =uglifyjs= will keep the text
+  marked /*! */ in the generated code (assumed to be license information
+  etc.).  If you pass this it will discard it.
+
 - =-o filename= or =--output filename= --- put the result in =filename=.  If
   this isn't given, the result goes to standard output (or see next one).
 

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -3,7 +3,7 @@
 
 global.sys = require(/^v0\.[012]/.test(process.version) ? "sys" : "util");
 var fs = require("fs");
-var uglify = require("uglify-js"), // symlink ~/.node_libraries/uglify-js.js to ../uglify-js.js
+var uglify = require("../uglify-js"), // symlink ~/.node_libraries/uglify-js.js to ../uglify-js.js
     consolidator = uglify.consolidator,
     jsp = uglify.parser,
     pro = uglify.uglify;
@@ -32,7 +32,8 @@ var options = {
                 indent_start: 0,
                 quote_keys: false,
                 space_colon: false,
-                inline_script: false
+                inline_script: false,
+                licenses: true
         },
         make: false,
         output: true            // stdout
@@ -85,6 +86,10 @@ out: while (args.length > 0) {
             case "--no-copyright":
             case "-nc":
                 options.show_copyright = false;
+                break;
+            case "--no-licenses":
+            case "-nl":
+                options.codegen_options.licenses = false;
                 break;
             case "-o":
             case "--output":

--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -558,8 +558,6 @@ function tokenizer($TEXT) {
                         for (var j=0; j<text.length+2; j++) {
                           next();
                         }
-                        // S.pos = i + 2;
-                        // S.line += text.split("\n").length - 1;
                         S.newline_before = text.indexOf("\n") >= 0;
                         return token("license", text);
                 });
@@ -578,6 +576,7 @@ function tokenizer($TEXT) {
                         S.regex_allowed = regex_allowed;
                         if (peek()=='!') {
                           // A license statment starts /*!
+                          next();
                           return read_license();
                         } else {
                           S.comments_before.push(read_multiline_comment());

--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -258,6 +258,12 @@ function JS_Parse_Error(message, line, col, pos) {
         this.col = col + 1;
         this.pos = pos + 1;
         this.stack = new Error().stack;
+        try {
+                ({})();
+        } catch(ex) {
+                this.stack = ex.stack;
+                console.log(this.toString());
+        };
 };
 
 JS_Parse_Error.prototype.toString = function() {
@@ -546,6 +552,21 @@ function tokenizer($TEXT) {
                 return token("operator", grow(prefix || next()));
         };
 
+        function read_license() {
+                next();
+                return with_eof_error("Unterminated multiline comment", function(){
+                        var i = find("*/", true),
+                            text = S.text.substring(S.pos, i);
+                        for (var j=0; j<text.length+2; j++) {
+                          next();
+                        }
+                        // S.pos = i + 2;
+                        // S.line += text.split("\n").length - 1;
+                        S.newline_before = text.indexOf("\n") >= 0;
+                        return token("license", text);
+                });
+        };
+
         function handle_slash() {
                 next();
                 var regex_allowed = S.regex_allowed;
@@ -555,8 +576,14 @@ function tokenizer($TEXT) {
                         S.regex_allowed = regex_allowed;
                         return next_token();
                     case "*":
-                        S.comments_before.push(read_multiline_comment());
+                        next();
                         S.regex_allowed = regex_allowed;
+                        if (peek()=='!') {
+                          // A license statment starts /*!
+                          return read_license();
+                        } else {
+                          S.comments_before.push(read_multiline_comment());
+                        }
                         return next_token();
                 }
                 return S.regex_allowed ? read_regexp("") : read_operator("/");
@@ -682,7 +709,6 @@ function NodeWithToken(str, start, end) {
 NodeWithToken.prototype.toString = function() { return this.name; };
 
 function parse($TEXT, exigent_mode, embed_tokens) {
-
         var S = {
                 input       : typeof $TEXT == "string" ? tokenizer($TEXT, true) : $TEXT,
                 token       : null,
@@ -755,7 +781,12 @@ function parse($TEXT, exigent_mode, embed_tokens) {
         };
 
         function as() {
-                return slice(arguments);
+                var arr = slice(arguments);
+                if (S.token.comments_before && S.token.comments_before.length) {
+                        arr.comments_before = S.token.comments_before;
+                }
+                if (S.token.line) arr.line = S.token.line;
+                return arr;
         };
 
         function parenthesised() {
@@ -791,6 +822,9 @@ function parse($TEXT, exigent_mode, embed_tokens) {
                     case "operator":
                     case "atom":
                         return simple_statement();
+
+                    case "license":
+                        return as("license", prog1(S.token.value, next));
 
                     case "name":
                         return is_token(peek(), "punc", ":")
@@ -884,6 +918,10 @@ function parse($TEXT, exigent_mode, embed_tokens) {
                         unexpected(start);
                 S.labels.pop();
                 return as("label", label, stat);
+        };
+
+        function license() {
+                return as("license", prog1(expression));
         };
 
         function simple_statement() {

--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -472,7 +472,6 @@ function tokenizer($TEXT) {
         };
 
         function read_multiline_comment() {
-                next();
                 return with_eof_error("Unterminated multiline comment", function(){
                         var i = find("*/", true),
                             text = S.text.substring(S.pos, i);
@@ -553,7 +552,6 @@ function tokenizer($TEXT) {
         };
 
         function read_license() {
-                next();
                 return with_eof_error("Unterminated multiline comment", function(){
                         var i = find("*/", true),
                             text = S.text.substring(S.pos, i);

--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -258,12 +258,6 @@ function JS_Parse_Error(message, line, col, pos) {
         this.col = col + 1;
         this.pos = pos + 1;
         this.stack = new Error().stack;
-        try {
-                ({})();
-        } catch(ex) {
-                this.stack = ex.stack;
-                console.log(this.toString());
-        };
 };
 
 JS_Parse_Error.prototype.toString = function() {
@@ -552,7 +546,7 @@ function tokenizer($TEXT) {
         };
 
         function read_license() {
-                return with_eof_error("Unterminated multiline comment", function(){
+                return with_eof_error("Unterminated license statement", function(){
                         var i = find("*/", true),
                             text = S.text.substring(S.pos, i);
                         for (var j=0; j<text.length+2; j++) {

--- a/lib/process.js
+++ b/lib/process.js
@@ -202,6 +202,9 @@ function ast_walker() {
                 },
                 "atom": function(name) {
                         return [ this[0], name ];
+                },
+                "license": function(name) {
+                        return [ this[0], name ];
                 }
         };
 
@@ -1547,6 +1550,9 @@ function gen_code(ast, options) {
                 "string": encode_string,
                 "num": make_num,
                 "name": make_name,
+                "license": function(x){
+                  return "/*!"+x+'*/';
+                },
                 "debugger": function(){ return "debugger" },
                 "toplevel": function(statements) {
                         return make_block_statements(statements)

--- a/lib/process.js
+++ b/lib/process.js
@@ -1421,7 +1421,8 @@ function gen_code(ast, options) {
                 space_colon  : false,
                 beautify     : false,
                 ascii_only   : false,
-                inline_script: false
+                inline_script: false,
+                licenses: true
         });
         var beautify = !!options.beautify;
         var indentation = 0,
@@ -1550,8 +1551,11 @@ function gen_code(ast, options) {
                 "string": encode_string,
                 "num": make_num,
                 "name": make_name,
-                "license": function(x){
-                  return "/*!"+x+'*/';
+                "license": function(text){
+                  if (!options.licenses) {
+                    return '';
+                  }
+                  return "/*!" + text + '*/';
                 },
                 "debugger": function(){ return "debugger" },
                 "toplevel": function(statements) {

--- a/test/testparser.js
+++ b/test/testparser.js
@@ -23,6 +23,7 @@ function ParserTestSuite(callback){
 		["var abc = 5;", "Regular variable statement with assignment"],
 		["/* */;", "Multiline comment"],
 		['/** **/;', 'Double star multiline comment'],
+		["/*! */;", "License statement"],
 		["var f = function(){;};", "Function expression in var assignment"],
 		['hi; // moo\n;', 'single line comment'],
 		['var varwithfunction;', 'Dont match keywords as substrings'], // difference between `var withsomevar` and `"str"` (local search and lits)

--- a/test/unit/compress/expected/license.js
+++ b/test/unit/compress/expected/license.js
@@ -1,0 +1,3 @@
+/*! License 1 *//*! Multiline
+    License 2
+*/var a=1;/*! License 3 */var b=1

--- a/test/unit/compress/test/license.js
+++ b/test/unit/compress/test/license.js
@@ -1,0 +1,7 @@
+/*! License 1 */
+/*! Multiline
+    License 2
+*/
+var a=1;
+/*! License 3 */
+var b=1;


### PR DESCRIPTION
Adding support for license statements marked like this:
/*!
  license
*/
These will be new elements in the AST, and will always be generated into the minified code.
This fixes #85, #306, some of #275, maybe some others.

I also pass the comments and line numbers out of the parser, by adding extra properties to the AST arrays.
This is useful to those using the parser without the minifier.
