### PR TITLE
Don't generate names listed in options.except

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -316,7 +316,7 @@ Scope.prototype = {
                 };
         },
 
-        next_mangled: function(options) {
+        next_mangled: function(except) {
                 // we must be careful that the new mangled name:
                 //
                 // 1. doesn't shadow a mangled name from a parent
@@ -332,8 +332,8 @@ Scope.prototype = {
                 // 3. doesn't shadow a name that is referenced but not
                 //    defined (possibly global defined elsewhere).
                 //
-                // 4. doesn't shadow an 'excepted' name, because that
-                //    might be a global.
+                // 4. doesn't shadow an excepted name from the 'except'
+                //    array, because that might be a global.
                 for (;;) {
                         var m = base54(++this.cname), prior;
 
@@ -352,7 +352,7 @@ Scope.prototype = {
                                 continue;
 
                         // case 4.
-                        if (options && options.except && member(m, options.except))
+                        if (except && member(m, except))
                                 continue;
 
                         // I got "do" once. :-/
@@ -366,13 +366,13 @@ Scope.prototype = {
                 this.rev_mangled[m] = name;
                 return this.mangled[name] = m;
         },
-        get_mangled: function(name, newMangle, options) {
+        get_mangled: function(name, newMangle, except) {
                 if (this.uses_eval || this.uses_with) return name; // no mangle if eval or with is in use
                 var s = this.has(name);
                 if (!s) return name; // not in visible scope, no mangle
                 if (HOP(s.mangled, name)) return s.mangled[name]; // already mangled in this scope
                 if (!newMangle) return name;                      // not found and no mangling requested
-                return s.set_mangle(name, s.next_mangled(options));
+                return s.set_mangle(name, s.next_mangled(except));
         },
         references: function(name) {
                 return name && !this.parent || this.uses_with || this.uses_eval || this.refs[name];
@@ -508,7 +508,7 @@ function ast_mangle(ast, options) {
                 if (!options.toplevel && !scope.parent) return name; // don't mangle toplevel
                 if (options.except && member(name, options.except))
                         return name;
-                return scope.get_mangled(name, newMangle, options);
+                return scope.get_mangled(name, newMangle, options.except);
         };
 
         function get_define(name) {
@@ -532,7 +532,7 @@ function ast_mangle(ast, options) {
                                 else if (body.scope.references(name)) {
                                         extra = {};
                                         if (!(scope.uses_eval || scope.uses_with))
-                                                name = extra[name] = scope.next_mangled(options);
+                                                name = extra[name] = scope.next_mangled(options.except);
                                         else
                                                 extra[name] = name;
                                 }

--- a/lib/process.js
+++ b/lib/process.js
@@ -316,7 +316,7 @@ Scope.prototype = {
                 };
         },
 
-        next_mangled: function() {
+        next_mangled: function(options) {
                 // we must be careful that the new mangled name:
                 //
                 // 1. doesn't shadow a mangled name from a parent
@@ -331,6 +331,9 @@ Scope.prototype = {
                 //
                 // 3. doesn't shadow a name that is referenced but not
                 //    defined (possibly global defined elsewhere).
+                //
+                // 4. doesn't shadow an 'excepted' name, because that
+                //    might be a global.
                 for (;;) {
                         var m = base54(++this.cname), prior;
 
@@ -348,6 +351,10 @@ Scope.prototype = {
                         if (HOP(this.refs, m) && this.refs[m] == null)
                                 continue;
 
+                        // case 4.
+                        if (options && options.except && member(m, options.except))
+                                continue;
+
                         // I got "do" once. :-/
                         if (!is_identifier(m))
                                 continue;
@@ -359,13 +366,13 @@ Scope.prototype = {
                 this.rev_mangled[m] = name;
                 return this.mangled[name] = m;
         },
-        get_mangled: function(name, newMangle) {
+        get_mangled: function(name, newMangle, options) {
                 if (this.uses_eval || this.uses_with) return name; // no mangle if eval or with is in use
                 var s = this.has(name);
                 if (!s) return name; // not in visible scope, no mangle
                 if (HOP(s.mangled, name)) return s.mangled[name]; // already mangled in this scope
                 if (!newMangle) return name;                      // not found and no mangling requested
-                return s.set_mangle(name, s.next_mangled());
+                return s.set_mangle(name, s.next_mangled(options));
         },
         references: function(name) {
                 return name && !this.parent || this.uses_with || this.uses_eval || this.refs[name];
@@ -501,7 +508,7 @@ function ast_mangle(ast, options) {
                 if (!options.toplevel && !scope.parent) return name; // don't mangle toplevel
                 if (options.except && member(name, options.except))
                         return name;
-                return scope.get_mangled(name, newMangle);
+                return scope.get_mangled(name, newMangle, options);
         };
 
         function get_define(name) {
@@ -525,7 +532,7 @@ function ast_mangle(ast, options) {
                                 else if (body.scope.references(name)) {
                                         extra = {};
                                         if (!(scope.uses_eval || scope.uses_with))
-                                                name = extra[name] = scope.next_mangled();
+                                                name = extra[name] = scope.next_mangled(options);
                                         else
                                                 extra[name] = name;
                                 }

--- a/test/unit/compress/expected/except.js
+++ b/test/unit/compress/expected/except.js
@@ -1,0 +1,1 @@
+(function(){function j(){i=2;var h=3,a=3}var a=1,b=1,c=1,d=1,e=1,f=1,g=1,h=1,i=1;j()})()

--- a/test/unit/compress/test/except.js
+++ b/test/unit/compress/test/except.js
@@ -1,0 +1,17 @@
+(function() {
+  var something_really_long=1;
+  var b1=1;
+  var c1=1;
+  var d1=1;
+  var e1=1;
+  var f1=1;
+  var g1=1;
+  var h=1;
+  var h1=1;
+  function test() {
+    h1=2;
+    var h=3;
+    var g=3;
+  }
+  test();
+}());

--- a/test/unit/scripts.js
+++ b/test/unit/scripts.js
@@ -11,7 +11,7 @@ var scriptsPath = __dirname;
 
 function compress(code) {
 	var ast = jsp.parse(code);
-	ast = pro.ast_mangle(ast);
+	ast = pro.ast_mangle(ast, { except: 'h' });
 	ast = pro.ast_squeeze(ast, { no_warnings: true });
         ast = pro.ast_squeeze_more(ast);
 	return pro.gen_code(ast);


### PR DESCRIPTION
We use options.except to ignore some globally-defined functions, such as $ or _.
Those names won't get mangled.
But currently, Uglify will still create new names with those names, which can cause clashes.

I've passed the options hash through to next_mangled() so it can check.
If the options hash isn't passed, the behaviour defaults to before.
I've also added a test.
