### PR TITLE
Allow defines even when not mangling.

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -290,8 +290,9 @@ function squeeze_it(code) {
                 if (options.lift_vars) {
                         ast = time_it("lift", function(){ return pro.ast_lift_variables(ast); });
                 }
-                if (options.mangle) ast = time_it("mangle", function(){
+                ast = time_it("mangle", function(){
                         return pro.ast_mangle(ast, {
+                                mangle       : options.mangle,
                                 toplevel     : options.mangle_toplevel,
                                 defines      : options.defines,
                                 except       : options.reserved_names,

--- a/lib/process.js
+++ b/lib/process.js
@@ -501,6 +501,7 @@ function ast_mangle(ast, options) {
         options = options || {};
 
         function get_mangled(name, newMangle) {
+                if (!options.mangle) return name;
                 if (!options.toplevel && !scope.parent) return name; // don't mangle toplevel
                 if (options.except && member(name, options.except))
                         return name;


### PR DESCRIPTION
Currently, --define X has no effect if --no-mangle is turned on.
