### PR TITLE
Fixing strict mode with generic directive support

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -684,13 +684,14 @@ NodeWithToken.prototype.toString = function() { return this.name; };
 function parse($TEXT, exigent_mode, embed_tokens) {
 
         var S = {
-                input       : typeof $TEXT == "string" ? tokenizer($TEXT, true) : $TEXT,
-                token       : null,
-                prev        : null,
-                peeked      : null,
-                in_function : 0,
-                in_loop     : 0,
-                labels      : []
+                input         : typeof $TEXT == "string" ? tokenizer($TEXT, true) : $TEXT,
+                token         : null,
+                prev          : null,
+                peeked        : null,
+                in_function   : 0,
+                in_directives : true,
+                in_loop       : 0,
+                labels        : []
         };
 
         S.token = next();
@@ -709,6 +710,9 @@ function parse($TEXT, exigent_mode, embed_tokens) {
                 } else {
                         S.token = S.input();
                 }
+                S.in_directives = S.in_directives && (
+                        S.token.type == "string" || is("punc", ";")
+                );
                 return S.token;
         };
 
@@ -786,10 +790,10 @@ function parse($TEXT, exigent_mode, embed_tokens) {
                 }
                 switch (S.token.type) {
                     case "string":
-                        if (S.token.value == "use strict") {
-                                next();
-                                return as("use-strict");
-                        }
+                        var dir = S.in_directives, stat = simple_statement();
+                        if (dir && stat[1][0] == "string" && !is("punc", ","))
+                            return as("directive", stat[1][1]);
+                        return stat;
                     case "num":
                     case "regexp":
                     case "operator":
@@ -964,10 +968,12 @@ function parse($TEXT, exigent_mode, embed_tokens) {
                           // body
                           (function(){
                                   ++S.in_function;
-                                  var loop = S.in_loop;
+                                  var directives = S.in_directives, loop = S.in_loop;
+                                  S.in_directives = true;
                                   S.in_loop = 0;
                                   var a = block_();
                                   --S.in_function;
+                                  S.in_directives = directives;
                                   S.in_loop = loop;
                                   return a;
                           })());

--- a/lib/process.js
+++ b/lib/process.js
@@ -203,8 +203,8 @@ function ast_walker() {
                 "atom": function(name) {
                         return [ this[0], name ];
                 },
-                "use-strict": function() {
-                        return this;
+                "directive": function(dir) {
+                        return [ this[0], dir ];
                 }
         };
 
@@ -607,6 +607,9 @@ function ast_mangle(ast, options) {
                         return with_scope(self.scope, function(){
                                 return [ self[0], MAP(body, walk) ];
                         });
+                },
+                "directive": function() {
+                        return MAP.at_top(this);
                 }
         }, function() {
                 return walk(ast_add_scope(ast));
@@ -1775,8 +1778,8 @@ function gen_code(ast, options) {
                 "atom": function(name) {
                         return make_name(name);
                 },
-                "use-strict": function() {
-                        return make_string("use strict") + ";";
+                "directive": function(dir) {
+                        return make_string(dir) + ";";
                 }
         }, function(){ return make(ast) });
 
@@ -1837,7 +1840,7 @@ function gen_code(ast, options) {
                                 return must_has_semicolon(node[3]); // dive into the `else' branch
                         }
                         return must_has_semicolon(node[2]); // dive into the `then' branch
-                    case "use-strict":
+                    case "directive":
                         return true;
                 }
         };


### PR DESCRIPTION
Improving `strict mode` support by ensuring functions do not get hoisted above directives. There's also support for arbitrary directives as [allowed for in the spec](http://twitter.com/#!/kangax/status/68022795614949376). It will preserve all semicolon terminated string literals until the first non-directive in each scope.

``` js
(function(){
    "use strict";
    function x(){}
})();
```

now becomes

``` js
(function(){"use strict";function a(){}})();
```

rather than

``` js
(function(){function a(){}"use strict"})();
```

These will be new elements in the AST, replacing the current `strict-mode` specific element.
This fixes #130.
