### PR TITLE
Fixes mishoo/UglifyJS/issues/363

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -279,7 +279,9 @@ function Scope(parent) {
         this.uses_eval = false; // will become TRUE if eval() is detected in this or any subscopes
         this.parent = parent;   // parent scope
         this.children = [];     // sub-scopes
+        this.except = null;     // except list
         if (parent) {
+                this.except = parent.except;
                 this.level = parent.level + 1;
                 parent.children.push(this);
         } else {
@@ -334,6 +336,9 @@ Scope.prototype = {
                 //
                 // 3. doesn't shadow a name that is referenced but not
                 //    defined (possibly global defined elsewhere).
+                //
+                // 4. is not in the reserved names list
+                //
                 for (;;) {
                         var m = base54(++this.cname), prior;
 
@@ -349,6 +354,10 @@ Scope.prototype = {
 
                         // case 3.
                         if (HOP(this.refs, m) && this.refs[m] == null)
+                                continue;
+
+                        // case 4
+                        if (this.except && member(m, this.except))
                                 continue;
 
                         // I got "do" once. :-/
@@ -545,6 +554,7 @@ function ast_mangle(ast, options) {
         function with_scope(s, cont, extra) {
                 var _scope = scope;
                 scope = s;
+                scope.except = options.except;
                 if (extra) for (var i in extra) if (HOP(extra, i)) {
                         s.set_mangle(i, extra[i]);
                 }


### PR DESCRIPTION
This fixes #363.  Scope needs to know the reserved names list, so it can know to skip the mangled name.  

However, I'm not sure how you would like this information to get to Scope.  Right now I set it in ast_mangle.with_scope, and also grab it from the parent if one exists.
