### PR TITLE
Squashable directives

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -277,6 +277,7 @@ function Scope(parent) {
         this.refs = {};         // names referenced from this scope
         this.uses_with = false; // will become TRUE if with() is detected in this or any subscopes
         this.uses_eval = false; // will become TRUE if eval() is detected in this or any subscopes
+        this.directives = [];   // directives activated from this scope
         this.parent = parent;   // parent scope
         this.children = [];     // sub-scopes
         if (parent) {
@@ -379,6 +380,9 @@ Scope.prototype = {
                                 this.names[name] = type || "var";
                         return name;
                 }
+        },
+        active: function(dir) {
+                return member(dir, this.directives) || this.parent && this.parent.active(dir);
         }
 };
 
@@ -1007,7 +1011,7 @@ function ast_squeeze(ast, options) {
                 keep_comps  : true
         });
 
-        var w = ast_walker(), walk = w.walk;
+        var w = ast_walker(), walk = w.walk, scope;
 
         function negate(c) {
                 var not_c = [ "unary-prefix", "!", c ];
@@ -1070,7 +1074,17 @@ function ast_squeeze(ast, options) {
         };
 
         function _lambda(name, args, body) {
-                return [ this[0], name, args, tighten(body, "lambda") ];
+                return [ this[0], name, args, with_scope(body.scope, function() {
+                        return tighten(body, "lambda");
+                }) ];
+        };
+
+        function with_scope(s, cont) {
+                var _scope = scope;
+                scope = s;
+                var ret = cont();
+                scope = _scope;
+                return ret;
         };
 
         // this function does a few things:
@@ -1289,7 +1303,9 @@ function ast_squeeze(ast, options) {
                 },
                 "if": make_if,
                 "toplevel": function(body) {
-                        return [ "toplevel", tighten(body) ];
+                        return with_scope(this.scope, function() {
+                            return [ "toplevel", tighten(body) ];
+                        });
                 },
                 "switch": function(expr, body) {
                         var last = body.length - 1;
@@ -1360,11 +1376,17 @@ function ast_squeeze(ast, options) {
                                 return [ this[0], rvalue[1], lvalue, rvalue[3] ]
                         }
                         return [ this[0], op, lvalue, rvalue ];
+                },
+                "directive": function(dir) {
+                        if (scope.active(dir))
+                            return [ "block" ];
+                        scope.directives.push(dir);
+                        return [ this[0], dir ];
                 }
         }, function() {
                 for (var i = 0; i < 2; ++i) {
                         ast = prepare_ifs(ast);
-                        ast = walk(ast);
+                        ast = walk(ast_add_scope(ast));
                 }
                 return ast;
         });

--- a/test/unit/compress/expected/issue372.js
+++ b/test/unit/compress/expected/issue372.js
@@ -1,0 +1,1 @@
+"use strict";function a(){function a(){function a(){void "c"}function b(){"salmon";void "d"}void "b"}function b(){"salmon";function a(){void "f";for(var a=0;a<10;a++)var b=function(){void "g"}()}void "e"}void "a"}

--- a/test/unit/compress/test/issue372.js
+++ b/test/unit/compress/test/issue372.js
@@ -1,0 +1,32 @@
+"use strict";
+"use strict";
+
+function a() {
+    void "a";
+    function b() {
+        "use strict";
+        void "b";
+        function c() {
+            "use strict";
+            void "c";
+        }
+        function d() {
+            "salmon";
+            void "d";
+        }
+    }
+    function e() {
+        "salmon";
+        void "e";
+        function f() {
+            "use strict";
+            "salmon";
+            void "f";
+            for (var i = 0; i < 10; i++) var g = function() {
+                "use strict";
+                "salmon";
+                void "g";
+            }();
+        }
+    }
+};


### PR DESCRIPTION
Used the pattern established in `ast_mangle` and `ast_lift_vars` to add scope awareness (`with_scope`) to `ast_squeeze` and remove redundant directives.
