### PR TITLE
Fix the --make argument in newer versions of node

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -213,7 +213,7 @@ if (options.make) {
         options.out_same_file = false; // doesn't make sense in this case
         var makefile = JSON.parse(fs.readFileSync(filename || "Makefile.uglify.js").toString());
         output(makefile.files.map(function(file){
-                var code = fs.readFileSync(file.name);
+                var code = fs.readFileSync(file.name).toString();
                 if (file.module) {
                         code = "!function(exports, global){global = this;\n" + code + "\n;this." + file.module + " = exports;}({})";
                 }


### PR DESCRIPTION
One liner because `fs.readFileSync(path)` now returns a `Buffer` and must be converted to a string.
