### PR TITLE
Preserve leading license comments from multiple files; //, /* and /*!

### DIFF
--- a/README.html
+++ b/README.html
@@ -381,14 +381,14 @@ for your shell-scripting needs:
 
 
 
-<pre class="src src-sh">uglifyjs [ options... ] [ filename ]
+<pre class="src src-sh">uglifyjs [ options... ] [ filenames... ]
 </pre>
 
 
 <p>
-<code>filename</code> should be the last argument and should name the file from which
-to read the JavaScript code.  If you don't specify it, it will read code
-from STDIN.
+<code>filenames</code> should come after all options and should name the files from
+which to read the JavaScript code.  If you don't specify it, it will read
+code from STDIN.
 </p>
 <p>
 Supported options:
@@ -398,7 +398,8 @@ Supported options:
   options control the beautifier:
 
 <ul>
-<li><code>-i N</code> or <code>--indent N</code> &mdash; indentation level (number of spaces)
+<li><code>-i N[,M]</code> or <code>--indent N[,M]</code> &mdash; indentation level (number of spaces)
+  and an optional second value for the starting level
 
 </li>
 <li><code>-q</code> or <code>--quote-keys</code> &mdash; quote keys in literal objects (by default,
@@ -457,6 +458,11 @@ Supported options:
   pass <code>--overwrite</code> then the output will be written in the same file.
 
 </li>
+<li><code>-s</code> or <code>--strict</code> &mdash; adds a global <code>&#8203;"use strict";= directive, allowing
+  it to be factored out of the code.  Ensure your code is strict mode compatible
+  before using this option.
+
+</li>
 <li><code>--ast</code> &mdash; pass this if you want to get the Abstract Syntax Tree instead
   of JavaScript as output.  Useful for debugging or learning more about the
   internals.
@@ -473,8 +479,9 @@ Supported options:
   argument may be specified multiple times to define multiple
   symbols - if no value is specified the symbol will be replaced with
   the value <code>true</code>, or you can specify a numeric value (such as
-  <code>1024</code>), a quoted string value (such as ="object"= or
-  ='https://github.com'<code>), or the name of another symbol or keyword   (such as =null</code> or <code>document</code>).
+  <code>1024</code>), a quoted string value (such as <code>&#8203;"object"&#8203;</code> or
+  <code>&#8203;'https://github.com'&#8203;</code>), a regular expression (such as <code>/[a-z0-9]/g</code>),
+  or the name of another symbol or keyword (such as <code>null</code> or <code>document</code>).
   This allows you, for example, to assign meaningful names to key
   constant values but discard the symbolic names in the uglified
   version for brevity/efficiency, or when used wth care, allows

--- a/README.org
+++ b/README.org
@@ -170,19 +170,20 @@ There is a command-line tool that exposes the functionality of this library
 for your shell-scripting needs:
 
 #+BEGIN_SRC sh
-uglifyjs [ options... ] [ filename ]
+uglifyjs [ options... ] [ filenames... ]
 #+END_SRC
 
-=filename= should be the last argument and should name the file from which
-to read the JavaScript code.  If you don't specify it, it will read code
-from STDIN.
+=filenames= should come after all options and should name the files from
+which to read the JavaScript code.  If you don't specify it, it will read
+code from STDIN.
 
 Supported options:
 
 - =-b= or =--beautify= --- output indented code; when passed, additional
   options control the beautifier:
 
-  - =-i N= or =--indent N= --- indentation level (number of spaces)
+  - =-i N[,M]= or =--indent N[,M]= --- indentation level (number of spaces)
+    and an optional second value for the starting level
 
   - =-q= or =--quote-keys= --- quote keys in literal objects (by default,
     only keys that cannot be identifier names will be quotes).
@@ -230,6 +231,10 @@ Supported options:
 - =--overwrite= --- if the code is read from a file (not from STDIN) and you
   pass =--overwrite= then the output will be written in the same file.
 
+- =-s= or =--strict= --- adds a global =​"use strict";= directive, allowing
+  it to be factored out of the code.  Ensure your code is strict mode compatible
+  before using this option.
+
 - =--ast= --- pass this if you want to get the Abstract Syntax Tree instead
   of JavaScript as output.  Useful for debugging or learning more about the
   internals.
@@ -244,9 +249,9 @@ Supported options:
   argument may be specified multiple times to define multiple
   symbols - if no value is specified the symbol will be replaced with
   the value =true=, or you can specify a numeric value (such as
-  =1024=), a quoted string value (such as ="object"= or
-  ='https://github.com'=), or the name of another symbol or keyword
-  (such as =null= or =document=).
+  =1024=), a quoted string value (such as =​"object"​= or
+  =​'https://github.com'​=), a regular expression (such as =/[a-z0-9]/g=),
+  or the name of another symbol or keyword (such as =null= or =document=).
   This allows you, for example, to assign meaningful names to key
   constant values but discard the symbolic names in the uglified
   version for brevity/efficiency, or when used wth care, allows

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -52,6 +52,7 @@ var args = jsp.slice(process.argv, 2),
 function copyright(code) {
     var result = '';
     if (options.copyright) {
+        // get comments from first token of a new tokenizer
         var comments = jsp.tokenizer(code)().comments_before;
         for (var i = 0, l = comments.length; i < l; i++) {
             var comment = comments[i];
@@ -69,6 +70,7 @@ function copyright(code) {
 function read(input, callback) {
     var count = 0,
         content = [];
+    // kick off async reads for all inputs
     input.forEach(function(path, i) {
         var code = '',
             stream = path === '-'
@@ -82,6 +84,7 @@ function read(input, callback) {
         stream.on('end', function() {
             content[i] = [ path, code ];
             if ( ++count === input.length ) {
+                // all reads have completed
                 callback(content);
             }
         });
@@ -96,6 +99,7 @@ function squeeze(code) {
             return jsp.parse(code);
         });
         if (options.strict) {
+            // add directive to global scope for squeezing
             ast[1].unshift([ 'directive', 'use strict' ]);
         }
         if (options.consolidate) {
@@ -132,6 +136,9 @@ function squeeze(code) {
             });
         }
         if (options.strict) {
+            // remove the fake directive
+            // this prevents duplicate global directives when combining multiple files
+            // the global directive will be output only once; see output()
             ast[1].shift();
         }
         if (options.ast) {

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -14,6 +14,7 @@ var uglify = require("../uglify-js"),
 // variables
 
 var args = jsp.slice(process.argv, 2),
+    comment = /^\/[\/\*]/,
     input = [],
     output = '-',
     options = {
@@ -187,7 +188,8 @@ function write(output, code) {
                      mode: 0644
                  });
     if (options.strict) {
-        var nl = options.beautify ? '\n\n' : /^\/[\/\*]/.test(code) ? '\n' : '';
+        // when neccessary write in global directive with correct spacing
+        var nl = options.beautify ? '\n\n' : comment.test(code) ? '\n' : '';
         stream.write('"use strict";' + nl);
     }
     stream.write(code.replace(/;*\s*$/, ''));
@@ -335,6 +337,19 @@ read(input, function(content) {
                 }
                 return item;
             });
+        }
+        if (!options.overwrite) {
+            // combine inputs that are not seperated by a leading comment for group squeezing
+            content = content.reduce(function(arr, item) {
+                var len = arr.length;
+                if (len && !comment.test(item[1].trim())) {
+                    arr[len-1][1] += '\n' + item[1];
+                } else {
+                    arr.push(item);
+                }
+                return arr;
+            }, []);
+            console.log(content);
         }
         content = content.map(function(item) {
             item[1] = squeeze(item[1]).trim();

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -68,6 +68,62 @@ function copyright(code) {
     return result;
 }
 
+function define(arg, module) {
+    function parse(val) {
+        var ast, leaf;
+        try {
+            ast = jsp.parse(val);
+            leaf = ast[1][0];
+            switch (leaf[0]) {
+                case 'directive':
+                    leaf[0] = 'string';
+                    break;
+                case 'stat':
+                    leaf = leaf[1];
+                    break;
+            }
+        } catch (err) {
+            leaf = [ 'block' ];
+        }
+        if (!jsp.member(leaf[0], ['name', 'num', 'regexp', 'string'])) {
+            if (!module && !(/"/.test(val) && /'/.test(val))) {
+                return [ 'string', val ];
+            }
+            throw "Expecting a literal, encountered: " + val;
+        }
+        return leaf;
+    }
+    function symbol(sym) {
+        if (jsp.KEYWORDS_ATOM.hasOwnProperty(sym)) {
+            throw "Don't define values for inbuilt constant '" + sym + "'";
+        }
+        return sym;
+    }
+    try {
+        if (module) {
+            var mod = require(arg);
+            for (sym in mod) {
+                if (mod.hasOwnProperty(sym)) {
+                    options.definitions[sym] = parse(sys.inspect(mod[sym]));
+                }
+            }
+        } else {
+            if (arg.match(/^([a-z_\$][a-z_\$0-9]*)(?:=(.*))?$/i)) {
+                var sym = symbol(RegExp.$1),
+                    val = RegExp.$2 ? parse(RegExp.$2) : [ 'name', 'true' ];
+                options.definitions[sym] = val;
+            }
+            else {
+                throw "The --define option expects SYMBOL[=value]";
+            }
+        }
+    } catch (err) {
+        sys.print('ERROR: In option --define' + (module ? '-from-module' : '') + ' ' + arg + '\n');
+        sys.print('ERROR: ' + err + '\n');
+        process.exit(1);
+    }
+}
+
 function read(input, callback) {
     var count = 0,
         content = [];
@@ -219,10 +275,10 @@ while (args.length > 0) {
             break;
         case '-d':
         case '--define':
-            read_definitions(args, options.definitions);
+            define(args.shift());
             break;
         case '--define-from-module':
-            read_module_definitions(args, options.definitions);
+            define(args.shift(), true);
             break;
         case '-i':
         case '--indent':
@@ -349,7 +405,6 @@ read(input, function(content) {
                 }
                 return arr;
             }, []);
-            console.log(content);
         }
         content = content.map(function(item) {
             item[1] = squeeze(item[1]).trim();

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -72,7 +72,9 @@ function define(arg, module) {
     function parse(val) {
         var ast, leaf;
         try {
+            // use parser to decipher definitions
             ast = jsp.parse(val);
+            // first node in toplevel
             leaf = ast[1][0];
             switch (leaf[0]) {
                 case 'directive':
@@ -83,9 +85,11 @@ function define(arg, module) {
                     break;
             }
         } catch (err) {
-            leaf = [ 'block' ];
+            // failed to parse
         }
-        if (!jsp.member(leaf[0], ['name', 'num', 'regexp', 'string'])) {
+        // allow only literals for now, potential for dependency injection
+        if (!leaf || !jsp.member(leaf[0], ['name', 'num', 'regexp', 'string'])) {
+            // fallback to string when appropriate
             if (!module && !(/"/.test(val) && /'/.test(val))) {
                 return [ 'string', val ];
             }
@@ -104,6 +108,7 @@ function define(arg, module) {
             var mod = require(arg);
             for (sym in mod) {
                 if (mod.hasOwnProperty(sym)) {
+                    // use sys.inspect to make mod[sym] parsable
                     options.definitions[sym] = parse(sys.inspect(mod[sym]));
                 }
             }

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -1,332 +1,346 @@
-#!/usr/bin/env node
+#! /usr/bin/env node
 // -*- js -*-
 
+// requires
+
 global.sys = require(/^v0\.[012]/.test(process.version) ? "sys" : "util");
+
 var fs = require("fs");
-var uglify = require("../uglify-js"), // symlink ~/.node_libraries/uglify-js.js to ../uglify-js.js
-    consolidator = uglify.consolidator,
+var uglify = require("../uglify-js"),
+    con = uglify.consolidator,
     jsp = uglify.parser,
     pro = uglify.uglify;
 
-var options = {
+// variables
+
+var args = jsp.slice(process.argv, 2),
+    input = [],
+    output = '-',
+    options = {
+        ascii: false,
         ast: false,
+        beautify: false,
         consolidate: false,
-        mangle: true,
-        mangle_toplevel: false,
-        no_mangle_functions: false,
-        squeeze: true,
-        make_seqs: true,
+        copyright: true,
         dead_code: true,
-        verbose: false,
-        show_copyright: true,
-        out_same_file: false,
-        max_line_length: 32 * 1024,
-        unsafe: false,
-        reserved_names: null,
-        defines: { },
-        lift_vars: false,
-        codegen_options: {
-                ascii_only: false,
-                beautify: false,
-                indent_level: 4,
-                indent_start: 0,
-                quote_keys: false,
-                space_colon: false,
-                inline_script: false
+        definitions: {},
+        hoist: false,
+        indent: {
+            level: 4,
+            start: 0
         },
+        inline: false,
         make: false,
-        output: true            // stdout
-};
+        mangle: {
+            functions: true,
+            general: true,
+            toplevel: false
+        },
+        overwrite: false,
+        quote_keys: false,
+        reserved: null,
+        sequences: true,
+        squeeze: true,
+        strict: false,
+        unsafe: false,
+        verbose: false,
+        wrap: 32 * 1024
+    };
 
-var args = jsp.slice(process.argv, 2);
-var filename;
+// functions
 
-out: while (args.length > 0) {
-        var v = args.shift();
-        switch (v) {
-            case "-b":
-            case "--beautify":
-                options.codegen_options.beautify = true;
-                break;
-            case "-c":
-            case "--consolidate-primitive-values":
-                options.consolidate = true;
-                break;
-            case "-i":
-            case "--indent":
-                options.codegen_options.indent_level = args.shift();
-                break;
-            case "-q":
-            case "--quote-keys":
-                options.codegen_options.quote_keys = true;
-                break;
-            case "-mt":
-            case "--mangle-toplevel":
-                options.mangle_toplevel = true;
-                break;
-            case "-nmf":
-            case "--no-mangle-functions":
-                options.no_mangle_functions = true;
-                break;
-            case "--no-mangle":
-            case "-nm":
-                options.mangle = false;
-                break;
-            case "--no-squeeze":
-            case "-ns":
-                options.squeeze = false;
-                break;
-            case "--no-seqs":
-                options.make_seqs = false;
-                break;
-            case "--no-dead-code":
-                options.dead_code = false;
-                break;
-            case "--no-copyright":
-            case "-nc":
-                options.show_copyright = false;
-                break;
-            case "-o":
-            case "--output":
-                options.output = args.shift();
-                break;
-            case "--overwrite":
-                options.out_same_file = true;
-                break;
-            case "-v":
-            case "--verbose":
-                options.verbose = true;
-                break;
-            case "--ast":
-                options.ast = true;
-                break;
-            case "--unsafe":
-                options.unsafe = true;
-                break;
-            case "--max-line-len":
-                options.max_line_length = parseInt(args.shift(), 10);
-                break;
-            case "--reserved-names":
-                options.reserved_names = args.shift().split(",");
-                break;
-            case "--lift-vars":
-                options.lift_vars = true;
-                break;
-            case "-d":
-            case "--define":
-                 var defarg = args.shift();
-                 try {
-                     var defsym = function(sym) {
-                             // KEYWORDS_ATOM doesn't include NaN or Infinity - should we check
-                             // for them too ?? We don't check reserved words and the like as the
-                             // define values are only substituted AFTER parsing
-                             if (jsp.KEYWORDS_ATOM.hasOwnProperty(sym)) {
-                                 throw "Don't define values for inbuilt constant '"+sym+"'";
-                             }
-                             return sym;
-                         },
-                         defval = function(v) {
-                             if (v.match(/^"(.*)"$/) || v.match(/^'(.*)'$/)) {
-                                 return [ "string", RegExp.$1 ];
-                             }
-                             else if (!isNaN(parseFloat(v))) {
-                                 return [ "num", parseFloat(v) ];
-                             }
-                             else if (v.match(/^[a-z\$_][a-z\$_0-9]*$/i)) {
-                                 return [ "name", v ];
-                             }
-                             else if (!v.match(/"/)) {
-                                 return [ "string", v ];
-                             }
-                             else if (!v.match(/'/)) {
-                                 return [ "string", v ];
-                             }
-                             throw "Can't understand the specified value: "+v;
-                         };
-                     if (defarg.match(/^([a-z_\$][a-z_\$0-9]*)(=(.*))?$/i)) {
-                         var sym = defsym(RegExp.$1),
-                             val = RegExp.$2 ? defval(RegExp.$2.substr(1)) : [ 'name', 'true' ];
-                         options.defines[sym] = val;
-                     }
-                     else {
-                         throw "The --define option expects SYMBOL[=value]";
-                     }
-                 } catch(ex) {
-                     sys.print("ERROR: In option --define "+defarg+"\n"+ex+"\n");
-                     process.exit(1);
-                 }
-                 break;
-            case "--define-from-module":
-                var defmodarg = args.shift(),
-                    defmodule = require(defmodarg),
-                    sym,
-                    val;
-                for (sym in defmodule) {
-                    if (defmodule.hasOwnProperty(sym)) {
-                        options.defines[sym] = function(val) {
-                            if (typeof val == "string")
-                                return [ "string", val ];
-                            if (typeof val == "number")
-                                return [ "num", val ];
-                            if (val === true)
-                                return [ 'name', 'true' ];
-                            if (val === false)
-                                return [ 'name', 'false' ];
-                            if (val === null)
-                                return [ 'name', 'null' ];
-                            if (val === undefined)
-                                return [ 'name', 'undefined' ];
-                            sys.print("ERROR: In option --define-from-module "+defmodarg+"\n");
-                            sys.print("ERROR: Unknown object type for: "+sym+"="+val+"\n");
-                            process.exit(1);
-                            return null;
-                        }(defmodule[sym]);
-                    }
-                }
-                break;
-            case "--ascii":
-                options.codegen_options.ascii_only = true;
-                break;
-            case "--make":
-                options.make = true;
-                break;
-            case "--inline-script":
-                options.codegen_options.inline_script = true;
-                break;
-            default:
-                filename = v;
-                break out;
+function copyright(code) {
+    var result = '';
+    if (options.copyright) {
+        var comments = jsp.tokenizer(code)().comments_before;
+        for (var i = 0, l = comments.length; i < l; i++) {
+            var comment = comments[i];
+            if (comment.type === 'comment1') {
+                comment = '//' + comment.value + '\n';
+            } else {
+                comment = '/*' + comment.value + '*/';
+            }
+            result += comment;
         }
+    }
+    return result;
+}
+
+function read(input, callback) {
+    var count = 0,
+        content = [];
+    input.forEach(function(path, i) {
+        var code = '',
+            stream = path === '-'
+                   ? process.stdin
+                   : fs.createReadStream(path, {
+                         encoding: 'utf8'
+                     });
+        stream.on('data', function(chunk) {
+            code += chunk;
+        });
+        stream.on('end', function() {
+            content[i] = [ path, code ];
+            if ( ++count === input.length ) {
+                callback(content);
+            }
+        });
+        stream.resume();
+    });
+}
+
+function squeeze(code) {
+    var result = copyright(code);
+    try {
+        var ast = time('parse', function() {
+            return jsp.parse(code);
+        });
+        if (options.strict) {
+            ast[1].unshift([ 'directive', 'use strict' ]);
+        }
+        if (options.consolidate) {
+            ast = time('consolidate', function() {
+                return con.ast_consolidate(ast);
+            });
+        }
+        if (options.hoist) {
+            ast = time('hoist', function() {
+                return pro.ast_lift_variables(ast);
+            });
+        }
+        if (options.mangle.general) {
+            ast = time('mangle', function(){
+                return pro.ast_mangle(ast, {
+                    defines: options.definitions,
+                    except: options.reserved,
+                    no_functions: !options.mangle.functions,
+                    toplevel: options.mangle.toplevel
+                });
+            });
+        }
+        if (options.squeeze) {
+            ast = time('squeeze', function() {
+                ast = pro.ast_squeeze(ast, {
+                    dead_code: options.dead_code,
+                    keep_comps: !options.unsafe,
+                    make_seqs: options.sequences
+                });
+                if (options.unsafe) {
+                    ast = pro.ast_squeeze_more(ast);
+                }
+                return ast;
+            });
+        }
+        if (options.strict) {
+            ast[1].shift();
+        }
+        if (options.ast) {
+            return sys.inspect(ast, null, null);
+        }
+        result += time('generate', function() {
+            return pro.gen_code(ast, {
+                ascii_only: options.ascii,
+                beautify: options.beautify,
+                indent_level: options.indent.level,
+                indent_start: options.indent.start,
+                inline_script: options.inline,
+                quote_keys: options.quote_keys,
+                space_colon: false
+            });
+        });
+        if (options.wrap && !options.beautify) {
+            result = time('split', function() {
+                return pro.split_lines(result, options.wrap);
+            });
+        }
+        return result;
+    } catch (err) {
+        sys.debug(err.stack);
+        sys.debug(sys.inspect(err));
+        sys.debug(JSON.stringify(err));
+        process.exit(1);
+    }
+}
+
+function time(name, cont) {
+    if (!options.verbose) return cont();
+    var start = new Date().getTime();
+    try {
+        return cont();
+    } finally {
+        sys.debug('// ' + name + ': ' + ((new Date().getTime() - start) / 1000).toFixed(3) + ' sec.');
+    }
+}
+
+function write(output, code) {
+    var stream = output === '-'
+               ? process.stdout
+               : fs.createWriteStream(output, {
+                     encoding: 'utf8',
+                     mode: 0644
+                 });
+    if (options.strict) {
+        var nl = options.beautify ? '\n\n' : /^\/[\/\*]/.test(code) ? '\n' : '';
+        stream.write('"use strict";' + nl);
+    }
+    stream.write(code.replace(/;*\s*$/, ''));
+    if ( output !== '-' ) {
+        stream.end();
+    }
+}
+
+// main
+
+while (args.length > 0) {
+    var v = args.shift();
+    switch (v) {
+        case '--ascii':
+            options.ascii = true;
+            break;
+        case '--ast':
+            options.ast = true;
+            break;
+        case '-b':
+        case '--beautify':
+            options.beautify = true;
+            break;
+        case '-c':
+        case '--consolidate-primitive-values':
+            options.consolidate = true;
+            break;
+        case '-d':
+        case '--define':
+            read_definitions(args, options.definitions);
+            break;
+        case '--define-from-module':
+            read_module_definitions(args, options.definitions);
+            break;
+        case '-i':
+        case '--indent':
+            v = args.shift().split(',');
+            options.indent.level = v[0];
+            options.indent.start = v[1] || 0;
+            break;
+        case '--inline-script':
+            options.inline = true;
+            break;
+        case '--lift-vars':
+            options.hoist = true;
+            break;
+        case '--make':
+            options.make = true;
+            break;
+        case '-mt':
+        case '--mangle-toplevel':
+            options.mangle.toplevel = true;
+            break;
+        case '--max-line-len':
+            options.wrap = parseInt(args.shift(), 10);
+            break;
+        case '-nc':
+        case '--no-copyright':
+            options.copyright = false;
+            break;
+        case '--no-dead-code':
+            options.dead_code = false;
+            break;
+        case '-nm':
+        case '--no-mangle':
+            options.mangle.general = false;
+            break;
+        case '-nmf':
+        case '--no-mangle-functions':
+            options.mangle.functions = false;
+            break;
+        case '--no-seqs':
+            options.sequences = false;
+            break;
+        case '-ns':
+        case '--no-squeeze':
+            options.squeeze = false;
+            break;
+        case '-o':
+        case '--output':
+            output = args.shift();
+            break;
+        case '--overwrite':
+            options.overwrite = true;
+            break;
+        case '-q':
+        case '--quote-keys':
+            options.quote_keys = true;
+            break;
+        case '--reserved-names':
+            options.reserved = args.shift().split(',');
+            break;
+        case '-s':
+        case '--strict':
+            options.strict = true;
+            break;
+        case '--unsafe':
+            options.unsafe = true;
+            break;
+        case '-v':
+        case '--verbose':
+            options.verbose = true;
+            break;
+        default:
+            input.push(v);
+    }
 }
 
 if (options.verbose) {
-        pro.set_logger(function(msg){
-                sys.debug(msg);
-        });
+    pro.set_logger(function(msg){
+        sys.debug(msg);
+    });
 }
 
 jsp.set_logger(function(msg){
-        sys.debug(msg);
+    sys.debug(msg);
 });
 
-if (options.make) {
-        options.out_same_file = false; // doesn't make sense in this case
-        var makefile = JSON.parse(fs.readFileSync(filename || "Makefile.uglify.js").toString());
-        output(makefile.files.map(function(file){
-                var code = fs.readFileSync(file.name);
+if (options.make && input.length < 2) {
+    var specification = input.length ? input[0] : 'Makefile.uglify.js';
+    try {
+        specification = JSON.parse(fs.readFileSync(specification, 'utf8'));
+        input = specification.files.map(function(item) {
+            return item.name;
+        });
+    } catch (err) {
+        specification = undefined;
+    }
+}
+
+if (!input.length) {
+    input = ['-'];
+}
+
+read(input, function(content) {
+    if (options.copyright || options.make || options.overwrite) {
+        if (options.make) {
+            content = content.map(function(item, i) {
+                var file = specification ? specification.files[i] : {};
                 if (file.module) {
-                        code = "!function(exports, global){global = this;\n" + code + "\n;this." + file.module + " = exports;}({})";
+                    item[1] = "!function(exports, global){global = this;\n" + item[1] + "\n;this." + file.module + " = exports;}({})";
                 }
                 else if (file.hide) {
-                        code = "(function(){" + code + "}());";
+                    item[1] = "(function(){" + item[1] + "}());";
                 }
-                return squeeze_it(code);
-        }).join("\n"));
-}
-else if (filename) {
-        fs.readFile(filename, "utf8", function(err, text){
-                if (err) throw err;
-                output(squeeze_it(text));
+                return item;
+            });
+        }
+        content = content.map(function(item) {
+            item[1] = squeeze(item[1]).trim();
+            if (options.overwrite) {
+                write(item[0], item[1]);
+            }
+            return item[1];
         });
-}
-else {
-        var stdin = process.openStdin();
-        stdin.setEncoding("utf8");
-        var text = "";
-        stdin.on("data", function(chunk){
-                text += chunk;
-        });
-        stdin.on("end", function() {
-                output(squeeze_it(text));
-        });
-}
-
-function output(text) {
-        var out;
-        if (options.out_same_file && filename)
-                options.output = filename;
-        if (options.output === true) {
-                out = process.stdout;
-        } else {
-                out = fs.createWriteStream(options.output, {
-                        flags: "w",
-                        encoding: "utf8",
-                        mode: 0644
-                });
-        }
-        out.write(text.replace(/;*$/, ";"));
-        if (options.output !== true) {
-                out.end();
-        }
-};
-
-// --------- main ends here.
-
-function show_copyright(comments) {
-        var ret = "";
-        for (var i = 0; i < comments.length; ++i) {
-                var c = comments[i];
-                if (c.type == "comment1") {
-                        ret += "//" + c.value + "\n";
-                } else {
-                        ret += "/*" + c.value + "*/";
-                }
-        }
-        return ret;
-};
-
-function squeeze_it(code) {
-        var result = "";
-        if (options.show_copyright) {
-                var tok = jsp.tokenizer(code), c;
-                c = tok();
-                result += show_copyright(c.comments_before);
-        }
-        try {
-                var ast = time_it("parse", function(){ return jsp.parse(code); });
-                if (options.consolidate) ast = time_it("consolidate", function(){
-                        return consolidator.ast_consolidate(ast);
-                });
-                if (options.lift_vars) {
-                        ast = time_it("lift", function(){ return pro.ast_lift_variables(ast); });
-                }
-                if (options.mangle) ast = time_it("mangle", function(){
-                        return pro.ast_mangle(ast, {
-                                toplevel     : options.mangle_toplevel,
-                                defines      : options.defines,
-                                except       : options.reserved_names,
-                                no_functions : options.no_mangle_functions
-                        });
-                });
-                if (options.squeeze) ast = time_it("squeeze", function(){
-                        ast = pro.ast_squeeze(ast, {
-                                make_seqs  : options.make_seqs,
-                                dead_code  : options.dead_code,
-                                keep_comps : !options.unsafe
-                        });
-                        if (options.unsafe)
-                                ast = pro.ast_squeeze_more(ast);
-                        return ast;
-                });
-                if (options.ast)
-                        return sys.inspect(ast, null, null);
-                result += time_it("generate", function(){ return pro.gen_code(ast, options.codegen_options) });
-                if (!options.codegen_options.beautify && options.max_line_length) {
-                        result = time_it("split", function(){ return pro.split_lines(result, options.max_line_length) });
-                }
-                return result;
-        } catch(ex) {
-                sys.debug(ex.stack);
-                sys.debug(sys.inspect(ex));
-                sys.debug(JSON.stringify(ex));
-                process.exit(1);
-        }
-};
-
-function time_it(name, cont) {
-        if (!options.verbose)
-                return cont();
-        var t1 = new Date().getTime();
-        try { return cont(); }
-        finally { sys.debug("// " + name + ": " + ((new Date().getTime() - t1) / 1000).toFixed(3) + " sec."); }
-};
+        if (options.overwrite) return;
+        write(output, content.join('\n'));
+    } else {
+        write(output, squeeze(content.reduce(function(code, item) {
+            return code + item[1];
+        }, '')));
+    }
+});

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -53,6 +53,8 @@ var args = jsp.slice(process.argv, 2),
 function copyright(code) {
     var result = '';
     if (options.copyright) {
+        // clear any directives hoisted by a previous run
+        code = code.replace(/^"[^"\n]+";\n/, '');
         // get comments from first token of a new tokenizer
         var comments = jsp.tokenizer(code)().comments_before;
         for (var i = 0, l = comments.length; i < l; i++) {

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 // -*- js -*-
 
 // requires

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -326,9 +326,9 @@ if (!input.length) {
 
 read(input, function(content) {
     if (options.copyright || options.make || options.overwrite) {
-        if (options.make) {
+        if (options.make && specification) {
             content = content.map(function(item, i) {
-                var file = specification ? specification.files[i] : {};
+                var file = specification.files[i];
                 if (file.module) {
                     item[1] = "!function(exports, global){global = this;\n" + item[1] + "\n;this." + file.module + " = exports;}({})";
                 }


### PR DESCRIPTION
Allows a user to specify more than one input file to uglify, and keep the comments from each; `-` can also be used to ask uglify to read input from `stdin`. This operates in a similar manner to the current `bin/uglify` in that it will only preserve the comment block at the top of each file.
#### Example

``` sh
$ uglifyjs jquery.js myapp.js
```

``` js
/*! jQuery v1.7.2 jquery.com | jquery.org/license */ [uglified jquery code]
// leading comment in myapp.js
[uglified myapp code]
```
#### Changes
- **change**: can supply multiple inputs
- **change**: `--define` accepts regular expressions
- **new**: `--strict` applies strict mode to output
- **fix**: documentation layout - [bug/fix](http://lists.gnu.org/archive/html/emacs-orgmode/2010-04/msg00330.html)
#### Note

This does not solve the problem being addressed in #332, it just improves the existing workaround in `bin/uglifyjs`.
