### PR TITLE
Revoke #368 and fix issue #383 to make jQuery tests pass

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -509,6 +509,9 @@ function ast_mangle(ast, options) {
                 if (!options.toplevel && !scope.parent) return name; // don't mangle toplevel
                 if (options.except && member(name, options.except))
                         return name;
+                if (options.no_functions && HOP(scope.names, name) &&
+                    (scope.names[name] == 'defun' || scope.names[name] == 'lambda'))
+                        return name;
                 return scope.get_mangled(name, newMangle);
         };
 
@@ -1505,7 +1508,7 @@ function gen_code(ast, options) {
 
         function parenthesize(expr) {
                 var gen = make(expr);
-                if (!/^\(/.test(gen)) for (var i = 1; i < arguments.length; ++i) {
+                for (var i = 1; i < arguments.length; ++i) {
                         var el = arguments[i];
                         if ((el instanceof Function && el(expr)) || expr[0] == el)
                                 return "(" + gen + ")";
@@ -1660,7 +1663,7 @@ function gen_code(ast, options) {
                         if (expr[0] == "num") {
                                 if (!/[a-f.]/i.test(out))
                                         out += ".";
-                        } else if (expr[0] != "function" && !/^\(/.test(out) && needs_parens(expr))
+                        } else if (expr[0] != "function" && needs_parens(expr))
                                 out = "(" + out + ")";
                         while (i < arguments.length)
                                 out += "." + make_name(arguments[i++]);


### PR DESCRIPTION
Without the revocation, 10 jQuery 1.7.2 unit tests fail. 
