### PR TITLE
Implement #368 (too many parentheses)

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1508,7 +1508,7 @@ function gen_code(ast, options) {
 
         function parenthesize(expr) {
                 var gen = make(expr);
-                for (var i = 1; i < arguments.length; ++i) {
+                if (!has_parens(gen)) for (var i = 1; i < arguments.length; ++i) {
                         var el = arguments[i];
                         if ((el instanceof Function && el(expr)) || expr[0] == el)
                                 return "(" + gen + ")";
@@ -1552,6 +1552,22 @@ function gen_code(ast, options) {
                 }
                 return !HOP(DOT_CALL_NO_PARENS, expr[0]);
         };
+
+        function has_parens(expr) {
+                var parentheses = 0, position = 0, token;
+                do {
+                        token = jsp.tokenizer(expr.slice(position))();
+                        position += token.endpos;
+                        if (token.type == "punc") {
+                                if (token.value == "(") {
+                                        ++parentheses;
+                                } else if (token.value == ")") {
+                                        --parentheses;
+                                }
+                        }
+                } while (position < expr.length && parentheses > 0);
+                return position == expr.length && parentheses == 0;
+        }
 
         function make_num(num) {
                 var str = num.toString(10), a = [ str.replace(/^0\./, ".") ], m;
@@ -1663,7 +1679,7 @@ function gen_code(ast, options) {
                         if (expr[0] == "num") {
                                 if (!/[a-f.]/i.test(out))
                                         out += ".";
-                        } else if (expr[0] != "function" && needs_parens(expr))
+                        } else if (expr[0] != "function" && !has_parens(out) && needs_parens(expr))
                                 out = "(" + out + ")";
                         while (i < arguments.length)
                                 out += "." + make_name(arguments[i++]);

--- a/test/unit/compress/expected/issue368.js
+++ b/test/unit/compress/expected/issue368.js
@@ -1,0 +1,1 @@
+({}).constructor,new((0,Math)?Function:Math),((0,0)&0).valueOf()

--- a/test/unit/compress/test/issue368.js
+++ b/test/unit/compress/test/issue368.js
@@ -1,0 +1,3 @@
+({}.constructor);
+new ((0, Math) ? Function : Math)();
+((0, 0) & 0).valueOf();


### PR DESCRIPTION
In contrast to 67e6163441f2a475084f4e5c9506326021e3e37e, the tokenizer is used.
