### PR TITLE
Fix issue #386

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1556,7 +1556,7 @@ function gen_code(ast, options) {
         function has_parens(expr) {
                 var parentheses = 0, position = 0, token;
                 do {
-                        token = jsp.tokenizer(expr.slice(position))();
+                        token = jsp.tokenizer("(" + expr.slice(position) + ")")();
                         position += token.endpos;
                         if (token.type == "punc") {
                                 if (token.value == "(") {


### PR DESCRIPTION
By adding additional parentheses around the expression to test in has_params, object and lambda expressions won't fail to parse there.
