### PR TITLE
fix failing compression tests

### DIFF
--- a/test/unit/scripts.js
+++ b/test/unit/scripts.js
@@ -11,7 +11,7 @@ var scriptsPath = __dirname;
 
 function compress(code) {
 	var ast = jsp.parse(code);
-	ast = pro.ast_mangle(ast);
+	ast = pro.ast_mangle(ast, { mangle: true });
 	ast = pro.ast_squeeze(ast, { no_warnings: true });
         ast = pro.ast_squeeze_more(ast);
 	return pro.gen_code(ast);


### PR DESCRIPTION
Turn on the new mangle option when calling ast_mangle in the compression unit test runner.

This makes all unit tests but issue368.js to pass when running <code>npm test</code>
