### PR TITLE
Optimize list of digits for generating identifiers for gzip compression. (fixes #142)

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -289,7 +289,7 @@ function Scope(parent) {
 };
 
 var base54 = (function(){
-        var DIGITS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
+        var DIGITS = "etnrisouaflchpdvmgybwESxTNCkLAOM_DPHBjFIqRUzWXV$JKQGYZ0516372984";
         return function(num) {
                 var ret = "", base = 54;
                 do {


### PR DESCRIPTION
The list is based on reserved words and identifiers used in dot-expressions. It saves a quite a few bytes.

The savings are about 100 bytes on jQuery 1.7.2 and the same goes for Prototype.
