### PR TITLE
Add base54 digits override for unit tests.

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -288,8 +288,15 @@ function Scope(parent) {
         }
 };
 
+function base54_digits() {
+        if (typeof DIGITS_OVERRIDE_FOR_TESTING != "undefined")
+                return DIGITS_OVERRIDE_FOR_TESTING;
+        else
+                return "etnrisouaflchpdvmgybwESxTNCkLAOM_DPHBjFIqRUzWXV$JKQGYZ0516372984";
+}
+
 var base54 = (function(){
-        var DIGITS = "etnrisouaflchpdvmgybwESxTNCkLAOM_DPHBjFIqRUzWXV$JKQGYZ0516372984";
+        var DIGITS = base54_digits();
         return function(num) {
                 var ret = "", base = 54;
                 do {

--- a/test/testconsolidator.js
+++ b/test/testconsolidator.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+global.DIGITS_OVERRIDE_FOR_TESTING = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
 
 'use strict';
 /*jshint bitwise:true, curly:true, eqeqeq:true, forin:true, immed:true,

--- a/test/testparser.js
+++ b/test/testparser.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+global.DIGITS_OVERRIDE_FOR_TESTING = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
 
 var parseJS = require("../lib/parse-js");
 var sys = require("sys");

--- a/test/unit/scripts.js
+++ b/test/unit/scripts.js
@@ -1,3 +1,5 @@
+global.DIGITS_OVERRIDE_FOR_TESTING = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
+
 var fs = require('fs'),
 	uglify = require('../../uglify-js'),
 	jsp = uglify.parser,
@@ -11,7 +13,7 @@ var scriptsPath = __dirname;
 
 function compress(code) {
 	var ast = jsp.parse(code);
-	ast = pro.ast_mangle(ast);
+	ast = pro.ast_mangle(ast, { mangle: true });
 	ast = pro.ast_squeeze(ast, { no_warnings: true });
         ast = pro.ast_squeeze_more(ast);
 	return pro.gen_code(ast);


### PR DESCRIPTION
Prevents unit tests from depending on how mangled variable name
generation is optimized for gzip compression.

A global seemed like the easiest way to accomplish this, but I'm open to suggestions on how to do it more cleanly.

Also, could someone check on the one remaining failing test, <code>test/unit/compress/test/issue349.js</code> ?
