### PR TITLE
Also descend arg AST nodes in ast_squeeze function-call handler

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1400,7 +1400,7 @@ function ast_squeeze(ast, options) {
                         if (options.unsafe && expr[0] == "dot" && expr[1][0] == "string" && expr[2] == "toString") {
                                 return expr[1];
                         }
-                        return [ this[0], expr, args ];
+                        return [ this[0], expr,  MAP(args, walk) ];
                 }
         }, function() {
                 for (var i = 0; i < 2; ++i) {


### PR DESCRIPTION
This fixes the one failing unit test.

Also, @mishoo: <code>npm install</code> from the UglifyJS dir should give you nodeunit :)

(After that it's just <code>npm test</code> to run them all.)
