### PR TITLE
Fix representation of infinite values

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1576,7 +1576,18 @@ function gen_code(ast, options) {
         };
 
         function make_num(num) {
-                var str = num.toString(10), a = [ str.replace(/^0\./, ".").replace('e+', 'e') ], m;
+                var str, a, m;
+                if (num === 1 / 0) {
+                        return "1/0";
+                }
+                if (num === -1 / 0) {
+                        return "-1/0";
+                }
+                if (isNaN(num)) {
+                        return "0/0";
+                }
+                str = num.toString(10);
+                a = [ str.replace(/^0\./, ".").replace('e+', 'e') ];
                 if (Math.floor(num) === num) {
                         if (num >= 0) {
                                 a.push("0x" + num.toString(16).toLowerCase(), // probably pointless

--- a/test/unit/compress/expected/infinite.js
+++ b/test/unit/compress/expected/infinite.js
@@ -1,0 +1,1 @@
+with({get NaN(){throw 0},get Infinity(){throw 0}})0/0,0/0,1/0,-1/0

--- a/test/unit/compress/test/infinite.js
+++ b/test/unit/compress/test/infinite.js
@@ -1,0 +1,1 @@
+with({get NaN(){throw 0},get Infinity(){throw 0}})(1/0)/(1/0),0/0,123456/0,-123456/0


### PR DESCRIPTION
Infinite numbers (NaN and Infinity) were represented incorrectly due
to make_num using the Number.prototype.toString method (15.7.4.2)
which in turn performs the abstract operation ToString (9.8) which
returns a string "NaN" or "Infinity" in accordance with the first and
the fourth step of 9.8.1.

As the corresponding value properties of the global object can be
"shadowed", representing such numbers as "NaN" and "Infinity" can lead
to incorrect behavior. For example:

``` javascript
with({
  get NaN() {
    throw new Error();
  }
}) {
  0 / 0;
}
```

This patch checks for the values in question in the make_num function
and represents them using MultiplicativeExpression nonterminals
(e.g. "0/0" instead of "NaN").
