### PR TITLE
Flatten sequences

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1417,6 +1417,18 @@ function ast_squeeze(ast, options) {
                                          : [ "num", 0 ], [ "num", 0 ] ];
 
                         return [ this[0], num ];
+                },
+                "seq": function() {
+                        return [ this[0] ].concat(
+                            MAP(slice(arguments), walk).reduce(function (list, expr) {
+                                if (expr[0] != "seq")
+                                        list.push(expr);
+                                else expr.slice(1).forEach(function (expr) {
+                                        list.push(expr);
+                                });
+                                return list;
+                            }, [])
+                        );
                 }
         }, function() {
                 for (var i = 0; i < 2; ++i) {


### PR DESCRIPTION
The current situation will result in nested sequences which are somewhat harder to work with.
This commit does not influence the code-generator in any way, but is does make working with
the processed AST easier since you do not have to worry about nested seqs.
