### PR TITLE
'keep_zeroes' option for gen_code()

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1482,7 +1482,8 @@ function gen_code(ast, options) {
                 space_colon  : false,
                 beautify     : false,
                 ascii_only   : false,
-                inline_script: false
+                inline_script: false,
+                keep_zeroes  : false
         });
         var beautify = !!options.beautify;
         var indentation = 0,
@@ -1596,7 +1597,7 @@ function gen_code(ast, options) {
         };
 
         function make_num(num) {
-                var str = num.toString(10), a = [ str.replace(/^0\./, ".").replace('e+', 'e') ], m;
+                var str = num.toString(10), a = [ options.keep_zeroes ? str : str.replace(/^0\./, ".").replace('e+', 'e') ], m;
                 if (Math.floor(num) === num) {
                         if (num >= 0) {
                                 a.push("0x" + num.toString(16).toLowerCase(), // probably pointless


### PR DESCRIPTION
I added this to add the ability to preserve the leading zeroes on numbers when they are processed in make_num(). 
