### PR TITLE
Support regular expression matches for `options.except` and the like

### DIFF
--- a/lib/parse-js.js
+++ b/lib/parse-js.js
@@ -1331,8 +1331,11 @@ function characters(str) {
 
 function member(name, array) {
         for (var i = array.length; --i >= 0;)
-                if (array[i] == name)
+                if (typeof array[i].exec == "function") {
+                        return !!array[i].exec(name);
+                } else if (array[i] == name) {
                         return true;
+                }
         return false;
 };
 


### PR DESCRIPTION
This is to support things like `ast_mangle(ast, {except: [/^[A-Z]/]})`

My main motivation is to avoid mangling CoffeeScript-generated constructor functions, since 99% of my code follows that naming convention anyway.
