### PR TITLE
gen_code: Added support for quote_char option.

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1461,7 +1461,7 @@ var DOT_CALL_NO_PARENS = jsp.array_to_hash([
     "defun"
 ]);
 
-function make_string(str, ascii_only) {
+function make_string(str, ascii_only, quote_char) {
     var dq = 0, sq = 0;
     str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g, function(s){
         switch (s) {
@@ -1479,7 +1479,10 @@ function make_string(str, ascii_only) {
         return s;
     });
     if (ascii_only) str = to_ascii(str);
-    if (dq > sq) return "'" + str.replace(/\x27/g, "\\'") + "'";
+
+    // Default to quote char with the fewest occurrences in the string:
+    quote_char = quote_char || (dq > sq ? "'" : '"');
+    if (quote_char === "'") return "'" + str.replace(/\x27/g, "\\'") + "'";
     else return '"' + str.replace(/\x22/g, '\\"') + '"';
 };
 
@@ -1501,7 +1504,8 @@ function gen_code(ast, options) {
         space_colon  : false,
         beautify     : false,
         ascii_only   : false,
-        inline_script: false
+        inline_script: false,
+        quote_char   : null // '"', "'", or null (means use the one with the fewest occurrences in the string)
     });
     var beautify = !!options.beautify;
     var indentation = 0,
@@ -1509,7 +1513,7 @@ function gen_code(ast, options) {
     space = beautify ? " " : "";
 
     function encode_string(str) {
-        var ret = make_string(str, options.ascii_only);
+        var ret = make_string(str, options.ascii_only, options.quote_char);
         if (options.inline_script)
             ret = ret.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
         return ret;
@@ -1869,7 +1873,7 @@ function gen_code(ast, options) {
             return make_name(name);
         },
         "directive": function(dir) {
-            return make_string(dir) + ";";
+            return make_string(dir, false, options.quote_char) + ";";
         }
     }, function(){ return make(ast) });
 


### PR DESCRIPTION
Can be either `'`, `"`, or `null` (`null` means choose the one with fewest occurrences in the string, like the previous behavior).

Use case: Serializing data-bind attributes (Knockout.js) into doublequote delimited attributes and avoiding an excessive number of `&quot;` entities.
