### PR TITLE
Add another option that mangles only variable names that match a regex 

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -35,15 +35,22 @@ var options = {
         inline_script: false
     },
     make: false,
-    output: true            // stdout
+    output: true,            // stdout\
+    regex_mangle: false,
+    regex_value:undefined
 };
 
 var args = jsp.slice(process.argv, 2);
 var filename;
-
 out: while (args.length > 0) {
     var v = args.shift();
     switch (v) {
+      case "-rm":
+      case "--regex_mangle":
+        options.regex_mangle = true;  
+        v = args.shift();
+        options.regex_value = v;
+        break;
       case "-b":
       case "--beautify":
         options.codegen_options.beautify = true;
@@ -292,6 +299,8 @@ function squeeze_it(code) {
         }
         ast = time_it("mangle", function(){
             return pro.ast_mangle(ast, {
+                regex_value  : options.regex_value,
+                regex_mangle : options.regex_mangle,
                 mangle       : options.mangle,
                 toplevel     : options.mangle_toplevel,
                 defines      : options.defines,

--- a/lib/process.js
+++ b/lib/process.js
@@ -509,6 +509,8 @@ function ast_add_scope(ast) {
 
 /* -----[ mangle names ]----- */
 
+
+
 function ast_mangle(ast, options) {
     var w = ast_walker(), walk = w.walk, scope;
     options = defaults(options, {
@@ -516,10 +518,17 @@ function ast_mangle(ast, options) {
         toplevel     : false,
         defines      : null,
         except       : null,
-        no_functions : false
-    });
-
+        no_functions : false,
+        regex_mangle : false,
+        regex_value  : undefined
+    }); 
+   
     function get_mangled(name, newMangle) {
+        if(options.regex_mangle && options.regex_value){
+            if(!(name.match(options.regex_value))){
+                return name;
+            }
+        }
         if (!options.mangle) return name;
         if (!options.toplevel && !scope.parent) return name; // don't mangle toplevel
         if (options.except && member(name, options.except))
@@ -528,7 +537,7 @@ function ast_mangle(ast, options) {
             (scope.names[name] == 'defun' || scope.names[name] == 'lambda'))
             return name;
         return scope.get_mangled(name, newMangle);
-    };
+    }  
 
     function get_define(name) {
         if (options.defines) {
@@ -538,7 +547,7 @@ function ast_mangle(ast, options) {
                 if (HOP(options.defines, name)) {
                     return options.defines[name];
                 }
-            }
+            } 
             return null;
         }
     };
@@ -589,7 +598,6 @@ function ast_mangle(ast, options) {
     function _breacont(label) {
         if (label) return [ this[0], scope.labels.get_mangled(label) ];
     };
-
     return w.with_walkers({
         "function": _lambda,
         "defun": function() {
@@ -611,12 +619,12 @@ function ast_mangle(ast, options) {
                 walk(stat)
             ];
             return walk(stat);
-        },
+        },  
         "break": _breacont,
         "continue": _breacont,
         "var": _vardefs,
         "const": _vardefs,
-        "name": function(name) {
+        "name": function(name) {   
             return get_define(name) || [ this[0], get_mangled(name) ];
         },
         "try": function(t, c, f) {


### PR DESCRIPTION
This patch helps us to mangle only specific variable names that match to a regular expression.
We can activate regex specific mangling  by option "-rm" or "--regex_mangle" followed by regex string which is to be matched with the variable name. 
This option is however overwritten by "-nm"(no mangle) option. 
