### PR TITLE
Removed duplicate "return" member

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -906,7 +906,6 @@ function for_side_effects(ast, handler) {
     return w.with_walkers({
         "try": found,
         "throw": found,
-        "return": found,
         "new": found,
         "switch": found,
         "break": found,


### PR DESCRIPTION
This fixes issues including the library with "use strict" which checks for this issue.
