### PR TITLE
add support for unique ids to help track down tricky minification issues

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -45,6 +45,9 @@ out: while (args.length > 0) {
     var v = args.shift();
     switch (v) {
       case "-b":
+      case "--unique_ids":
+        options.unique_ids = true;
+        break;
       case "--beautify":
         options.codegen_options.beautify = true;
         break;
@@ -296,7 +299,8 @@ function squeeze_it(code) {
                 toplevel     : options.mangle_toplevel,
                 defines      : options.defines,
                 except       : options.reserved_names,
-                no_functions : options.no_mangle_functions
+                no_functions : options.no_mangle_functions,
+                unique_ids   : options.unique_ids
             });
         });
         if (options.squeeze) ast = time_it("squeeze", function(){

--- a/lib/process.js
+++ b/lib/process.js
@@ -270,6 +270,7 @@ function ast_walker() {
 };
 
 /* -----[ Scope and mangling ]----- */
+mangled_id = 0;    // for unique mangled names
 
 function Scope(parent) {
     this.names = {};        // names defined in this scope
@@ -329,7 +330,7 @@ Scope.prototype = {
         };
     },
 
-    next_mangled: function() {
+    next_mangled: function(unique_ids) {
         // we must be careful that the new mangled name:
         //
         // 1. doesn't shadow a mangled name from a parent
@@ -364,6 +365,8 @@ Scope.prototype = {
             // I got "do" once. :-/
             if (!is_identifier(m))
                 continue;
+            if (unique_ids)
+                return m + mangled_id++;
 
             return m;
         }
@@ -372,13 +375,13 @@ Scope.prototype = {
         this.rev_mangled[m] = name;
         return this.mangled[name] = m;
     },
-    get_mangled: function(name, newMangle) {
+    get_mangled: function(name, newMangle, unique_ids) {
         if (this.uses_eval || this.uses_with) return name; // no mangle if eval or with is in use
         var s = this.has(name);
         if (!s) return name; // not in visible scope, no mangle
         if (HOP(s.mangled, name)) return s.mangled[name]; // already mangled in this scope
         if (!newMangle) return name;                      // not found and no mangling requested
-        return s.set_mangle(name, s.next_mangled());
+        return s.set_mangle(name, s.next_mangled(unique_ids));
     },
     references: function(name) {
         return name && !this.parent || this.uses_with || this.uses_eval || this.refs[name];
@@ -516,7 +519,8 @@ function ast_mangle(ast, options) {
         toplevel     : false,
         defines      : null,
         except       : null,
-        no_functions : false
+        no_functions : false,
+        unique_ids   : false
     });
 
     function get_mangled(name, newMangle) {
@@ -527,7 +531,7 @@ function ast_mangle(ast, options) {
         if (options.no_functions && HOP(scope.names, name) &&
             (scope.names[name] == 'defun' || scope.names[name] == 'lambda'))
             return name;
-        return scope.get_mangled(name, newMangle);
+        return scope.get_mangled(name, newMangle, options.unique_ids);
     };
 
     function get_define(name) {


### PR DESCRIPTION
sometimes (especially with AngularJS) you get errors only in your uglified code that are about function(e){}
which is hard to track down when there are 4700 function(e){}

This option makes each parameter name unique to help you find the area of code where the problem was.
see http://stackoverflow.com/a/25109762/1969871 for an example. I'm not suggesting you use it all the time, but just to help track down problems if they happen.

Hopefully you think this is useful. I'm not sure it's the best way to implement it, but it worked for me.
